### PR TITLE
feat(add no-pr option): add an option to skip creating PRs on submit

### DIFF
--- a/src/commands/branch-commands/submit.ts
+++ b/src/commands/branch-commands/submit.ts
@@ -14,6 +14,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       scope: 'BRANCH',
       editPRFieldsInline: argv.edit,
       createNewPRsAsDraft: argv.draft,
+      dontCreatePRs: !argv.pr,
       dryRun: argv['dry-run'],
       updateOnly: argv['update-only'],
       reviewers: argv.reviewers,

--- a/src/commands/downstack-commands/submit.ts
+++ b/src/commands/downstack-commands/submit.ts
@@ -13,6 +13,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       scope: 'DOWNSTACK',
       editPRFieldsInline: argv.edit,
       createNewPRsAsDraft: argv.draft,
+      dontCreatePRs: !argv.pr,
       dryRun: argv['dry-run'],
       updateOnly: argv['update-only'],
       reviewers: argv.reviewers,

--- a/src/commands/shared-commands/submit.ts
+++ b/src/commands/shared-commands/submit.ts
@@ -44,6 +44,12 @@ export const args = {
     type: 'boolean',
     default: false,
   },
+  'pr': {
+    describe:
+      'Submits PRs for branches. It --no-pr is true, no PRs are opened or updated.',
+    type: 'boolean',
+    default: true,
+  },
   'update-only': {
     describe: 'Only update the PRs that have been already been submitted.',
     type: 'boolean',

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -13,6 +13,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       scope: 'FULLSTACK',
       editPRFieldsInline: argv.edit,
       createNewPRsAsDraft: argv.draft,
+      dontCreatePRs: !argv.pr,
       dryRun: argv['dry-run'],
       updateOnly: argv['update-only'],
       reviewers: argv.reviewers,

--- a/src/commands/upstack-commands/submit.ts
+++ b/src/commands/upstack-commands/submit.ts
@@ -13,6 +13,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       scope: 'UPSTACK',
       editPRFieldsInline: argv.edit,
       createNewPRsAsDraft: argv.draft,
+      dontCreatePRs: !argv.pr,
       dryRun: argv['dry-run'],
       updateOnly: argv['update-only'],
       reviewers: argv.reviewers,


### PR DESCRIPTION
**Context:**

- Adding an option to skip submitting PRs, e.g. `gt stack submit --no-pr`

**Changes In This Pull Request:**

- Updated the `submit` logic to get the optional `--no-pr` flag, and skip creating/updating PRs if the flag is set

**Test Plan:**
- *NOT TESTED* - Could you please test the changes, review and then merge?

