### PR TITLE
Add alias for global --no-verify (-n)

### DIFF
--- a/src/lib/global-arguments/index.ts
+++ b/src/lib/global-arguments/index.ts
@@ -9,7 +9,7 @@ const globalArgumentsOptions = {
     demandOption: false,
   },
   quiet: { alias: 'q', default: false, type: 'boolean', demandOption: false },
-  verify: { default: true, type: 'boolean', demandOption: false },
+  "no-verify": { alias: 'n', default: true, type: 'boolean', demandOption: false },
   debug: { default: false, type: 'boolean', demandOption: false },
 } as const;
 
@@ -20,7 +20,7 @@ type argsT = yargs.Arguments<
 function processGlobalArgumentsMiddleware(argv: argsT): void {
   execStateConfig
     .setQuiet(argv.quiet)
-    .setNoVerify(!argv.verify)
+    .setNoVerify(argv["no-verify"])
     .setInteractive(argv.interactive)
     .setOutputDebugLogs(argv.debug);
 }

--- a/src/lib/global-arguments/index.ts
+++ b/src/lib/global-arguments/index.ts
@@ -9,7 +9,7 @@ const globalArgumentsOptions = {
     demandOption: false,
   },
   quiet: { alias: 'q', default: false, type: 'boolean', demandOption: false },
-  "no-verify": { alias: 'n', default: true, type: 'boolean', demandOption: false },
+  "no-verify": { alias: 'n', default: false, type: 'boolean', demandOption: false },
   debug: { default: false, type: 'boolean', demandOption: false },
 } as const;
 


### PR DESCRIPTION
**Context:**

- Add alias for global --no-verify (-n)
- Very similar to the standarized version of `git commit -n`

**Changes In This Pull Request:**

- Modify the args to be `no-verify` instead of `verify` to be able to support the `-n`  

**Test Plan:**
- *NO TESTS* - Could you please add tests and verify this works?

