### PR TITLE
chore(package): adjust npm name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphite-cli",
+  "name": "@graphitedev/graphite-cli",
   "version": "0.17.2",
   "license": "None",
   "main": "dist/index.js",


### PR DESCRIPTION
**Context:**
Change because the plain `graphite-cli` is taken
