### PR TITLE
refactor(repo_config): use injection

### DIFF
--- a/src/actions/init.ts
+++ b/src/actions/init.ts
@@ -63,10 +63,7 @@ export async function init(
     });
     repoConfig.addIgnoreBranchPatterns(ignoreBranches);
   } else {
-    let ignoreBranches = await selectIgnoreBranches(
-      allBranches,
-      newTrunkName
-    );
+    let ignoreBranches = await selectIgnoreBranches(allBranches, newTrunkName);
     logInfo(`Selected following branches to ignore: ${ignoreBranches}`);
     if (!ignoreBranches) {
       ignoreBranches = [];
@@ -74,15 +71,15 @@ export async function init(
     repoConfig.addIgnoreBranchPatterns(ignoreBranches);
   }
 
-  logInfo(`Graphite repo config saved at "${repoConfig.path()}"`);
-  logInfo(fs.readFileSync(repoConfig.path()).toString());
+  logInfo(`Graphite repo config saved at "${repoConfig.path}"`);
+  logInfo(fs.readFileSync(repoConfig.path).toString());
 }
 
 function logWelcomeMessage(): void {
   if (!repoConfig.graphiteInitialized()) {
     logInfo('Welcome to Graphite!');
   } else {
-    logInfo(`Regenerating Graphite repo config (${repoConfig.path()})`);
+    logInfo(`Regenerating Graphite repo config (${repoConfig.path})`);
   }
 }
 

--- a/src/commands/repo-commands/ignored_branches.ts
+++ b/src/commands/repo-commands/ignored_branches.ts
@@ -1,8 +1,8 @@
+import chalk from 'chalk';
 import yargs from 'yargs';
 import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { gpExecSync, logInfo, logWarn } from '../../lib/utils';
-import chalk from 'chalk';
 
 const args = {
   add: {

--- a/src/commands/repo-commands/max_branch_length.ts
+++ b/src/commands/repo-commands/max_branch_length.ts
@@ -5,8 +5,7 @@ import { logInfo } from '../../lib/utils';
 
 const args = {
   set: {
-    demandOption: false,
-    default: false,
+    optional: true,
     type: 'number',
     alias: 's',
     describe:
@@ -24,9 +23,9 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     if (argv.set) {
-      repoConfig.setMaxBranchLength(argv.set);
+      repoConfig.update((data) => (data.maxBranchLength = argv.set));
     } else {
-      logInfo(`${repoConfig.getMaxBranchLength().toString()} commits`);
+      logInfo(`${repoConfig.getMaxBranchLength.toString()} commits`);
     }
   });
 };

--- a/src/commands/repo-commands/max_days_behind_trunk.ts
+++ b/src/commands/repo-commands/max_days_behind_trunk.ts
@@ -5,8 +5,7 @@ import { logInfo } from '../../lib/utils';
 
 const args = {
   set: {
-    demandOption: false,
-    default: false,
+    optional: true,
     type: 'number',
     alias: 's',
     describe:
@@ -24,7 +23,7 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     if (argv.set) {
-      repoConfig.setMaxDaysShownBehindTrunk(argv.set);
+      repoConfig.update((data) => (data.maxDaysShownBehindTrunk = argv.set));
     } else {
       logInfo(repoConfig.getMaxDaysShownBehindTrunk().toString());
     }

--- a/src/commands/repo-commands/max_stacks_behind_trunk.ts
+++ b/src/commands/repo-commands/max_stacks_behind_trunk.ts
@@ -5,8 +5,7 @@ import { logInfo } from '../../lib/utils';
 
 const args = {
   set: {
-    demandOption: false,
-    default: false,
+    optional: true,
     type: 'number',
     alias: 's',
     describe:
@@ -24,7 +23,7 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     if (argv.set) {
-      repoConfig.setMaxStacksShownBehindTrunk(argv.set);
+      repoConfig.update((data) => (data.maxStacksShownBehindTrunk = argv.set));
     } else {
       logInfo(repoConfig.getMaxStacksShownBehindTrunk().toString());
     }

--- a/src/commands/repo-commands/repo_name.ts
+++ b/src/commands/repo-commands/repo_name.ts
@@ -5,8 +5,7 @@ import { logInfo } from '../../lib/utils';
 
 const args = {
   set: {
-    demandOption: false,
-    default: false,
+    optional: true,
     type: 'string',
     alias: 's',
     describe:
@@ -24,7 +23,7 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     if (argv.set) {
-      repoConfig.setRepoName(argv.set);
+      repoConfig.update((data) => (data.name = argv.set));
     } else {
       logInfo(repoConfig.getRepoName());
     }

--- a/src/commands/repo-commands/repo_owner.ts
+++ b/src/commands/repo-commands/repo_owner.ts
@@ -5,8 +5,7 @@ import { logInfo } from '../../lib/utils';
 
 const args = {
   set: {
-    demandOption: false,
-    default: false,
+    optional: false,
     type: 'string',
     alias: 's',
     describe:
@@ -24,7 +23,7 @@ export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async () => {
     if (argv.set) {
-      repoConfig.setRepoOwner(argv.set);
+      repoConfig.update((data) => (data.owner = argv.set));
     } else {
       logInfo(repoConfig.getRepoOwner());
     }

--- a/src/lib/config/compose_config.ts
+++ b/src/lib/config/compose_config.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+/* eslint-disable @typescript-eslint/ban-types */
+import * as t from '@withgraphite/retype';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { ExitFailedError } from '../errors';
+import { getRepoRootPath } from './repo_root_path';
+
+type TDefaultConfigLocation = {
+  relativePath: string;
+  relativeTo: 'USER_HOME' | 'REPO';
+};
+
+type TConfigMutator<TConfigData> = (data: TConfigData) => void;
+type TConfigTemplate<TConfigData, THelperFunctions> = {
+  defaultLocations: TDefaultConfigLocation[];
+  schema: t.Schema<TConfigData>;
+  initialize: () => unknown;
+  helperFunctions: (
+    data: TConfigData,
+    update: (mutator: TConfigMutator<TConfigData>) => void
+  ) => THelperFunctions;
+};
+
+type TConfigInstance<TConfigData, THelperFunctions> = {
+  readonly data: TConfigData;
+  readonly update: (mutator: TConfigMutator<TConfigData>) => void;
+  readonly path: string;
+} & THelperFunctions;
+
+type TConfigFactory<TConfigData, THelperFunctions> = {
+  load: (configPath?: string) => TConfigInstance<TConfigData, THelperFunctions>;
+};
+
+export function composeConfig<TConfigData, THelperFunctions>(
+  configTemplate: TConfigTemplate<TConfigData, THelperFunctions>
+): TConfigFactory<TConfigData, THelperFunctions> {
+  return {
+    load: (defaultPathOverride?: string) => {
+      const configPaths = configAbsolutePaths(
+        configTemplate.defaultLocations,
+        defaultPathOverride
+      );
+      const curPath =
+        configPaths.find((p) => fs.existsSync(p)) || configPaths[0];
+      const _data: TConfigData = readOrInitConfig(
+        curPath,
+        configTemplate.schema,
+        configTemplate.initialize
+      );
+      const update = (mutator: TConfigMutator<TConfigData>) => {
+        mutator(_data);
+        fs.writeFileSync(curPath, JSON.stringify(_data, null, 2));
+      };
+      return {
+        data: _data,
+        update,
+        path: curPath,
+        ...configTemplate.helperFunctions(_data, update),
+      };
+    },
+  };
+}
+
+function configAbsolutePaths(
+  defaultLocations: TDefaultConfigLocation[],
+  defaultPathOverride?: string
+): string[] {
+  const repoRoot = path.join(process.cwd(), getRepoRootPath());
+  const home = os.homedir();
+  return (defaultPathOverride ? [defaultPathOverride] : []).concat(
+    defaultLocations.map((l) =>
+      path.join(l.relativeTo === 'REPO' ? repoRoot : home, l.relativePath)
+    )
+  );
+}
+
+function readOrInitConfig<TConfigData>(
+  configPath: string,
+  schema: t.Schema<TConfigData>,
+  initialize: () => unknown
+): TConfigData {
+  const hasExistingConfig = configPath && fs.existsSync(configPath);
+  const rawConfig = hasExistingConfig
+    ? JSON.parse(fs.readFileSync(configPath).toString())
+    : initialize();
+
+  const validConfigFile = schema(rawConfig, { logFailures: true });
+  if (!validConfigFile) {
+    throw new ExitFailedError(`Malformed config file at ${configPath}`);
+  }
+  return rawConfig;
+}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -3,7 +3,7 @@ import execStateConfig from './exec_state_config';
 import messageConfig, {
   readMessageConfigForTestingOnly,
 } from './message_config';
-import repoConfig, { getOwnerAndNameFromURLForTesting } from './repo_config';
+import { getOwnerAndNameFromURLForTesting, repoConfig } from './repo_config';
 import { getRepoRootPath } from './repo_root_path';
 import userConfig from './user_config';
 

--- a/src/lib/context/context.ts
+++ b/src/lib/context/context.ts
@@ -1,0 +1,8 @@
+import { repoConfigFactory } from './../config/repo_config';
+export type TContext = {
+  repoConfig: ReturnType<typeof repoConfigFactory.load>;
+};
+
+export function initContext(): TContext {
+  return { repoConfig: repoConfigFactory.load() };
+}

--- a/src/lib/debug-context/index.ts
+++ b/src/lib/debug-context/index.ts
@@ -34,7 +34,7 @@ export function captureState(): string {
     refTree,
     branchToRefMapping,
     userConfig: JSON.stringify(userConfig._data),
-    repoConfig: JSON.stringify(repoConfig._data),
+    repoConfig: JSON.stringify(repoConfig.data),
     metadata,
     currentBranchName,
   };

--- a/src/lib/requests/fetch_pr_info.ts
+++ b/src/lib/requests/fetch_pr_info.ts
@@ -10,14 +10,14 @@ export function refreshPRInfoInBackground(): void {
   }
 
   const now = Date.now();
-  const lastFetchedMs = repoConfig.getLastFetchedPRInfoMs();
+  const lastFetchedMs = repoConfig.data.lastFetchedPRInfoMs;
   const msInSecond = 1000;
 
   // rate limit refreshing PR info to once per minute
   if (lastFetchedMs === undefined || now - lastFetchedMs > 60 * msInSecond) {
     // do our potential write before we kick off the child process so that we
     // don't incur a possible race condition with the write
-    repoConfig.setLastFetchedPRInfoMs(now);
+    repoConfig.update((data) => (data.lastFetchedPRInfoMs = now));
 
     cp.spawn('/usr/bin/env', ['node', __filename], {
       detached: true,

--- a/src/lib/telemetry/profile.ts
+++ b/src/lib/telemetry/profile.ts
@@ -44,7 +44,7 @@ export async function profile(
     startTime: start,
   });
 
-  if (parsedArgs.command !== 'repo init' && !repoConfig.getTrunk()) {
+  if (parsedArgs.command !== 'repo init' && !repoConfig.graphiteInitialized()) {
     logInfo(`Graphite has not been initialized, attempting to setup now...`);
     logNewline();
     await init();

--- a/src/lib/utils/trunk.ts
+++ b/src/lib/utils/trunk.ts
@@ -51,7 +51,7 @@ export function getTrunk(): Branch {
   if (memoizedTrunk) {
     return memoizedTrunk;
   }
-  const configTrunkName = repoConfig.getTrunk();
+  const configTrunkName = repoConfig.data.trunk;
   if (configTrunkName) {
     if (!Branch.exists(configTrunkName)) {
       throw new ExitFailedError(

--- a/test/fast/commands/repo/ignored_branches.test.ts
+++ b/test/fast/commands/repo/ignored_branches.test.ts
@@ -10,7 +10,9 @@ for (const scene of [new TrailingProdScene()]) {
     it('Can add to ignored-branches', () => {
       const repoConfigPath = `${scene.repo.dir}/.git/.graphite_repo_config`;
       fs.removeSync(repoConfigPath);
-      scene.repo.execCliCommand('repo init --trunk main');
+      scene.repo.execCliCommand(
+        'repo init --trunk main --ignore-branches "x2"' // ignore x2 to skip prompt
+      );
       const branchToAdd = 'prod';
       scene.repo.execCliCommand(`repo ignored-branches --add ${branchToAdd}`);
       const savedConfig = JSON.parse(
@@ -22,7 +24,9 @@ for (const scene of [new TrailingProdScene()]) {
     it('Can remove from ignored-branches', () => {
       const repoConfigPath = `${scene.repo.dir}/.git/.graphite_repo_config`;
       fs.removeSync(repoConfigPath);
-      scene.repo.execCliCommand('repo init --trunk main');
+      scene.repo.execCliCommand(
+        'repo init --trunk main --ignore-branches "x2"' // ignore x2 to skip prompt
+      );
       const branch = 'prod';
       scene.repo.execCliCommand(`repo ignored-branches --add ${branch}`);
       let savedConfig = JSON.parse(fs.readFileSync(repoConfigPath).toString());

--- a/test/fast/commands/repo/stack_settings.test.ts
+++ b/test/fast/commands/repo/stack_settings.test.ts
@@ -1,7 +1,4 @@
 import { expect } from 'chai';
-import fs from 'fs-extra';
-import path from 'path';
-import { repoConfig } from '../../../../src/lib/config';
 import { BasicScene } from '../../../lib/scenes';
 import { configureTest } from '../../../lib/utils';
 
@@ -25,36 +22,5 @@ for (const scene of [new BasicScene()]) {
           .includes('2')
       ).to.be.true;
     });
-
-    it('Can read log settings written in the old log settings location', () => {
-      const config = {
-        trunk: 'main',
-        ignoreBranches: [],
-        logSettings: {
-          maxStacksShownBehindTrunk: 5,
-          maxDaysShownBehindTrunk: 10,
-        },
-      };
-      writeRepoConfig(config);
-
-      expect(
-        scene.repo
-          .execCliCommandAndGetOutput('repo max-stacks-behind-trunk')
-          .includes('5')
-      ).to.be.true;
-
-      expect(
-        scene.repo
-          .execCliCommandAndGetOutput('repo max-days-behind-trunk')
-          .includes('10')
-      ).to.be.true;
-    });
   });
-
-  function writeRepoConfig(newConfig: {}): void {
-    fs.writeFileSync(
-      path.join(scene.dir, repoConfig.path()),
-      JSON.stringify(newConfig, null, 2)
-    );
-  }
 }

--- a/test/fast/commands/repo/sync.test.ts
+++ b/test/fast/commands/repo/sync.test.ts
@@ -42,6 +42,7 @@ for (const scene of allScenes) {
       expectBranches(scene.repo, 'a, main');
 
       fakeGitSquashAndMerge(scene.repo, 'a', 'squash');
+      scene.repo.execCliCommand(`repo owner`);
       scene.repo.execCliCommand(`repo sync -qf --no-pull --no-resubmit`);
 
       expectBranches(scene.repo, 'main');


### PR DESCRIPTION
**Context:**

We've been using a bit of a bad pattern for our various CLI config files - global class based singletons. Among other issues, these create flaky CI failures when running parallelized tests.

This change:
* Starts a pattern of using functional coding for configs over classes
* Set up room to override config location in future (will be useful for parallel CI tests)
* Starts angling towards a pattern of factory rather than global singleton, which we'll take advantage of upstack.
