### PR TITLE
refactor(context): limit using globals

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -1,15 +1,19 @@
 import { execStateConfig } from '../lib/config';
+import { TContext } from '../lib/context/context';
 import { ExitFailedError } from '../lib/errors';
 import { uncommittedTrackedChangesPrecondition } from '../lib/preconditions';
 import { gpExecSync, logWarn } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
 import { fixAction } from './fix';
 
-export async function commitAmendAction(opts: {
-  addAll: boolean;
-  message?: string;
-  noEdit: boolean;
-}): Promise<void> {
+export async function commitAmendAction(
+  opts: {
+    addAll: boolean;
+    message?: string;
+    noEdit: boolean;
+  },
+  context: TContext
+): Promise<void> {
   if (opts.addAll) {
     gpExecSync(
       {
@@ -51,10 +55,13 @@ export async function commitAmendAction(opts: {
   // Only restack if working tree is now clean.
   try {
     uncommittedTrackedChangesPrecondition();
-    await fixAction({
-      action: 'rebase',
-      mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,
-    });
+    await fixAction(
+      {
+        action: 'rebase',
+        mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,
+      },
+      context
+    );
   } catch {
     logWarn(
       'Cannot fix upstack automatically, some uncommitted changes remain. Please commit or stash, and then `gt stack fix --rebase`'

--- a/src/actions/commit_create.ts
+++ b/src/actions/commit_create.ts
@@ -1,4 +1,5 @@
 import { execStateConfig } from '../lib/config';
+import { TContext } from '../lib/context/context';
 import { ExitFailedError } from '../lib/errors';
 import {
   ensureSomeStagedChangesPrecondition,
@@ -7,10 +8,13 @@ import {
 import { gpExecSync, logWarn } from '../lib/utils';
 import { fixAction } from './fix';
 
-export async function commitCreateAction(opts: {
-  addAll: boolean;
-  message: string | undefined;
-}): Promise<void> {
+export async function commitCreateAction(
+  opts: {
+    addAll: boolean;
+    message: string | undefined;
+  },
+  context: TContext
+): Promise<void> {
   if (opts.addAll) {
     gpExecSync(
       {
@@ -56,10 +60,13 @@ export async function commitCreateAction(opts: {
 
   try {
     uncommittedTrackedChangesPrecondition();
-    await fixAction({
-      action: 'rebase',
-      mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,
-    });
+    await fixAction(
+      {
+        action: 'rebase',
+        mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER' as const,
+      },
+      context
+    );
   } catch {
     logWarn(
       'Cannot fix upstack automatically, some uncommitted changes remain. Please commit or stash, and then `gt stack fix --rebase`'

--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -1,4 +1,5 @@
 import { execStateConfig, userConfig } from '../lib/config';
+import { TContext } from '../lib/context/context';
 import { ExitFailedError } from '../lib/errors';
 import { currentBranchPrecondition } from '../lib/preconditions';
 import { checkoutBranch, gpExecSync } from '../lib/utils';
@@ -18,12 +19,15 @@ const EMPTY_COMMIT_MESSAGE_INFO = [
 function stringToTmpFileInput(contents: string): string {
   return `<(printf '%s\n' "${contents}")`;
 }
-export async function createBranchAction(opts: {
-  branchName?: string;
-  commitMessage?: string;
-  addAll?: boolean;
-}): Promise<void> {
-  const parentBranch = currentBranchPrecondition();
+export async function createBranchAction(
+  opts: {
+    branchName?: string;
+    commitMessage?: string;
+    addAll?: boolean;
+  },
+  context: TContext
+): Promise<void> {
+  const parentBranch = currentBranchPrecondition(context);
 
   if (opts.addAll) {
     gpExecSync(

--- a/src/actions/edit/apply_stack_edit_pick.ts
+++ b/src/actions/edit/apply_stack_edit_pick.ts
@@ -1,3 +1,4 @@
+import { TContext } from '../../lib/context/context';
 import { checkoutBranch } from '../../lib/utils';
 import Branch from '../../wrapper-classes/branch';
 import { stackOnto } from '../onto/stack_onto';
@@ -6,19 +7,23 @@ import { TStackEdit, TStackEditPick } from './stack_edits';
 
 export async function applyStackEditPick(
   stackEdit: TStackEditPick,
-  remainingEdits: TStackEdit[]
+  remainingEdits: TStackEdit[],
+  context: TContext
 ): Promise<void> {
   checkoutBranch(stackEdit.branchName);
-  await stackOnto({
-    currentBranch: new Branch(stackEdit.branchName),
-    onto: stackEdit.onto,
-    mergeConflictCallstack: {
-      parent: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
-      frame: {
-        op: 'STACK_EDIT_CONTINUATION',
-        currentBranch: stackEdit.branchName,
-        remainingEdits: remainingEdits,
-      } as TStackEditStackFrame,
+  await stackOnto(
+    {
+      currentBranch: new Branch(stackEdit.branchName),
+      onto: stackEdit.onto,
+      mergeConflictCallstack: {
+        parent: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
+        frame: {
+          op: 'STACK_EDIT_CONTINUATION',
+          currentBranch: stackEdit.branchName,
+          remainingEdits: remainingEdits,
+        } as TStackEditStackFrame,
+      },
     },
-  });
+    context
+  );
 }

--- a/src/actions/edit/create_stack_edit_file.ts
+++ b/src/actions/edit/create_stack_edit_file.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import { TContext } from '../../lib/context/context';
 import { getTrunk } from '../../lib/utils';
 import Stack from '../../wrapper-classes/stack';
 
@@ -23,11 +24,14 @@ pick    gf--02-09-first
 
 */
 
-export function createStackEditFile(opts: {
-  stack: Stack;
-  tmpDir: string;
-}): string {
-  const trunkName = getTrunk().name;
+export function createStackEditFile(
+  opts: {
+    stack: Stack;
+    tmpDir: string;
+  },
+  context: TContext
+): string {
+  const trunkName = getTrunk(context).name;
   const branchNames = opts.stack
     .branches()
     .map((b) => b.name)

--- a/src/actions/edit/parse_stack_edit_file.ts
+++ b/src/actions/edit/parse_stack_edit_file.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { TContext } from '../../lib/context/context';
 import { ExitFailedError } from '../../lib/errors';
 import { getTrunk } from '../../lib/utils';
 import {
@@ -7,7 +8,10 @@ import {
   TStackEditType,
 } from './stack_edits';
 
-export function parseEditFile(opts: { filePath: string }): TStackEdit[] {
+export function parseEditFile(
+  opts: { filePath: string },
+  context: TContext
+): TStackEdit[] {
   const fileContents = fs.readFileSync(opts.filePath).toString();
   const parsedEdit = fileContents
     .split('\n')
@@ -22,7 +26,7 @@ export function parseEditFile(opts: { filePath: string }): TStackEdit[] {
 
   parsedEdit.reverse();
 
-  if (parsedEdit.map((e) => e.branchName).includes(getTrunk().name)) {
+  if (parsedEdit.map((e) => e.branchName).includes(getTrunk(context).name)) {
     throw new ExitFailedError(`Cannot perform edits on trunk branch`);
   }
 
@@ -31,7 +35,8 @@ export function parseEditFile(opts: { filePath: string }): TStackEdit[] {
     return {
       type: parsedStackEdit.type,
       branchName: parsedStackEdit.branchName,
-      onto: index === 0 ? getTrunk().name : parsedEdit[index - 1].branchName,
+      onto:
+        index === 0 ? getTrunk(context).name : parsedEdit[index - 1].branchName,
     };
   });
 }

--- a/src/actions/fix_dangling_branches.ts
+++ b/src/actions/fix_dangling_branches.ts
@@ -1,23 +1,34 @@
 import chalk from 'chalk';
 import prompts from 'prompts';
-import { repoConfig } from '../lib/config';
 import { KilledError } from '../lib/errors';
 import { getTrunk, logInfo } from '../lib/utils';
 import Branch from '../wrapper-classes/branch';
+import { TContext } from './../lib/context/context';
 
-export function existsDanglingBranches(): boolean {
-  const danglingBranches = Branch.allBranchesWithFilter({
-    filter: (b) => !b.isTrunk() && b.getParentFromMeta() === undefined,
-  });
+export function existsDanglingBranches(context: TContext): boolean {
+  const danglingBranches = Branch.allBranchesWithFilter(
+    {
+      filter: (b) =>
+        !b.isTrunk(context) && b.getParentFromMeta(context) === undefined,
+    },
+    context
+  );
   return danglingBranches.length > 0;
 }
 
-export async function fixDanglingBranches(force: boolean): Promise<void> {
-  const danglingBranches = Branch.allBranchesWithFilter({
-    filter: (b) => !b.isTrunk() && b.getParentFromMeta() === undefined,
-  });
+export async function fixDanglingBranches(
+  context: TContext,
+  force: boolean
+): Promise<void> {
+  const danglingBranches = Branch.allBranchesWithFilter(
+    {
+      filter: (b) =>
+        !b.isTrunk(context) && b.getParentFromMeta(context) === undefined,
+    },
+    context
+  );
 
-  const trunk = getTrunk().name;
+  const trunk = getTrunk(context).name;
   for (const branch of danglingBranches) {
     type TFixStrategy = 'parent_trunk' | 'ignore_branch' | 'no_fix' | undefined;
     let fixStrategy: TFixStrategy | undefined = undefined;
@@ -74,7 +85,7 @@ export async function fixDanglingBranches(force: boolean): Promise<void> {
         branch.setParentBranchName(trunk);
         break;
       case 'ignore_branch':
-        repoConfig.addIgnoreBranchPatterns([branch.name]);
+        context.repoConfig.addIgnoreBranchPatterns([branch.name]);
         break;
       case 'no_fix':
         break;

--- a/src/actions/interactive_checkout.ts
+++ b/src/actions/interactive_checkout.ts
@@ -1,11 +1,15 @@
 import prompts from 'prompts';
+import { TContext } from '../lib/context/context';
 import { ExitCancelledError, ExitFailedError } from '../lib/errors';
 import { getTrunk, gpExecSync } from '../lib/utils';
 import { MetaStackBuilder } from '../wrapper-classes';
 import Branch from '../wrapper-classes/branch';
 
-export async function interactiveCheckout(): Promise<void> {
-  const stack = new MetaStackBuilder().fullStackFromBranch(getTrunk());
+export async function interactiveCheckout(context: TContext): Promise<void> {
+  const stack = new MetaStackBuilder().fullStackFromBranch(
+    getTrunk(context),
+    context
+  );
   await promptBranches(stack.toPromptChoices());
 }
 

--- a/src/actions/onto/current_branch_onto.ts
+++ b/src/actions/onto/current_branch_onto.ts
@@ -1,24 +1,31 @@
 import { MergeConflictCallstackT } from '../../lib/config/merge_conflict_callstack_config';
+import { TContext } from '../../lib/context/context';
 import { PreconditionsFailedError } from '../../lib/errors';
 import { currentBranchPrecondition } from '../../lib/preconditions';
 import { checkoutBranch, trackedUncommittedChanges } from '../../lib/utils';
 import { stackOnto } from './stack_onto';
 
-export async function currentBranchOntoAction(args: {
-  onto: string;
-  mergeConflictCallstack: MergeConflictCallstackT;
-}): Promise<void> {
+export async function currentBranchOntoAction(
+  args: {
+    onto: string;
+    mergeConflictCallstack: MergeConflictCallstackT;
+  },
+  context: TContext
+): Promise<void> {
   if (trackedUncommittedChanges()) {
     throw new PreconditionsFailedError('Cannot fix with uncommitted changes');
   }
 
-  const originalBranch = currentBranchPrecondition();
+  const originalBranch = currentBranchPrecondition(context);
 
-  await stackOnto({
-    currentBranch: originalBranch,
-    onto: args.onto,
-    mergeConflictCallstack: args.mergeConflictCallstack,
-  });
+  await stackOnto(
+    {
+      currentBranch: originalBranch,
+      onto: args.onto,
+      mergeConflictCallstack: args.mergeConflictCallstack,
+    },
+    context
+  );
 
   checkoutBranch(originalBranch.name);
 }

--- a/src/actions/submit/pr_body.ts
+++ b/src/actions/submit/pr_body.ts
@@ -2,18 +2,22 @@ import { execSync } from 'child_process';
 import fs from 'fs-extra';
 import prompts from 'prompts';
 import tmp from 'tmp';
+import { TContext } from '../../lib/context/context';
 import { KilledError } from '../../lib/errors';
 import { getSingleCommitOnBranch } from '../../lib/utils';
 import { getDefaultEditorOrPrompt } from '../../lib/utils/default_editor';
 import { getPRTemplate } from '../../lib/utils/pr_templates';
 import Branch from '../../wrapper-classes/branch';
 
-export async function getPRBody(args: {
-  branch: Branch;
-  editPRFieldsInline: boolean;
-}): Promise<string> {
+export async function getPRBody(
+  args: {
+    branch: Branch;
+    editPRFieldsInline: boolean;
+  },
+  context: TContext
+): Promise<string> {
   const template = await getPRTemplate();
-  const inferredBodyFromCommit = inferPRBody(args.branch);
+  const inferredBodyFromCommit = inferPRBody(args.branch, context);
   let body =
     inferredBodyFromCommit !== null ? inferredBodyFromCommit : template;
   const hasPRTemplate = body !== undefined;
@@ -60,14 +64,14 @@ async function editPRBody(args: {
   return contents;
 }
 
-export function inferPRBody(branch: Branch): string | null {
+export function inferPRBody(branch: Branch, context: TContext): string | null {
   const priorSubmitBody = branch.getPriorSubmitBody();
   if (priorSubmitBody !== undefined) {
     return priorSubmitBody;
   }
 
   // Only infer the title from the commit if the branch has just 1 commit.
-  const singleCommit = getSingleCommitOnBranch(branch);
+  const singleCommit = getSingleCommitOnBranch(branch, context);
   const singleCommitBody =
     singleCommit === null ? null : singleCommit.messageBody().trim();
 

--- a/src/actions/submit/pr_title.ts
+++ b/src/actions/submit/pr_title.ts
@@ -1,13 +1,17 @@
 import prompts from 'prompts';
+import { TContext } from '../../lib/context/context';
 import { KilledError } from '../../lib/errors';
 import { getSingleCommitOnBranch } from '../../lib/utils';
 import Branch from '../../wrapper-classes/branch';
 
-export async function getPRTitle(args: {
-  branch: Branch;
-  editPRFieldsInline: boolean;
-}): Promise<string> {
-  let title = inferPRTitle(args.branch);
+export async function getPRTitle(
+  args: {
+    branch: Branch;
+    editPRFieldsInline: boolean;
+  },
+  context: TContext
+): Promise<string> {
+  let title = inferPRTitle(args.branch, context);
   if (args.editPRFieldsInline) {
     const response = await prompts(
       {
@@ -27,19 +31,19 @@ export async function getPRTitle(args: {
   return title;
 }
 
-export function inferPRTitle(branch: Branch): string {
+export function inferPRTitle(branch: Branch, context: TContext): string {
   const priorSubmitTitle = branch.getPriorSubmitTitle();
   if (priorSubmitTitle !== undefined) {
     return priorSubmitTitle;
   }
 
   // Only infer the title from the commit if the branch has just 1 commit.
-  const singleCommit = getSingleCommitOnBranch(branch);
+  const singleCommit = getSingleCommitOnBranch(branch, context);
   const singleCommitSubject =
     singleCommit === null ? null : singleCommit.messageSubject().trim();
 
   if (singleCommitSubject !== null && singleCommitSubject.length > 0) {
     return singleCommitSubject;
   }
-  return `Merge ${branch.name} into ${branch.getParentFromMeta()!.name}`;
+  return `Merge ${branch.name} into ${branch.getParentFromMeta(context)!.name}`;
 }

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -1,3 +1,4 @@
+import { TContext } from '../lib/context/context';
 import { ValidationFailedError } from '../lib/errors';
 import { currentBranchPrecondition } from '../lib/preconditions';
 import { logInfo } from '../lib/utils';
@@ -6,33 +7,52 @@ import Branch from '../wrapper-classes/branch';
 import { TScope } from './scope';
 import { TSubmitScope } from './submit/submit';
 
-export function validateStack(scope: TSubmitScope, stack: Stack): void {
-  const branch = currentBranchPrecondition();
+export function validateStack(
+  scope: TSubmitScope,
+  stack: Stack,
+  context: TContext
+): void {
+  const branch = currentBranchPrecondition(context);
   switch (scope) {
     case 'FULLSTACK': {
-      const gitStack = new GitStackBuilder().fullStackFromBranch(branch);
+      const gitStack = new GitStackBuilder().fullStackFromBranch(
+        branch,
+        context
+      );
       compareStacks(stack, gitStack);
       break;
     }
     case 'UPSTACK': {
       const gitStack =
-        new GitStackBuilder().upstackInclusiveFromBranchWithParents(branch);
+        new GitStackBuilder().upstackInclusiveFromBranchWithParents(
+          branch,
+          context
+        );
       // Since we're modifying the stack, we want to make sure not to modify
       // the passed-in value. We re-derive the stack here but can improve this
       // in the future by just deep-copying the stack.
       const metadataStack =
-        new MetaStackBuilder().upstackInclusiveFromBranchWithParents(branch);
+        new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
+          branch,
+          context
+        );
       metadataStack.source.parent = undefined;
       gitStack.source.parent = undefined;
       compareStacks(metadataStack, gitStack);
       break;
     }
     case 'DOWNSTACK': {
-      const gitStack = new GitStackBuilder().downstackFromBranch(branch);
+      const gitStack = new GitStackBuilder().downstackFromBranch(
+        branch,
+        context
+      );
       // Since we're modifying the stack, we want to make sure not to modify
       // the passed-in value. We re-derive the stack here but can improve this
       // in the future by just deep-copying the stack.
-      const metadataStack = new MetaStackBuilder().downstackFromBranch(branch);
+      const metadataStack = new MetaStackBuilder().downstackFromBranch(
+        branch,
+        context
+      );
       metadataStack.source.children = [];
       gitStack.source.children = [];
       compareStacks(metadataStack, gitStack);
@@ -42,41 +62,51 @@ export function validateStack(scope: TSubmitScope, stack: Stack): void {
   logInfo(`Validation for current stack: passed`);
 }
 
-export function validate(scope: TScope): void {
-  const branch = currentBranchPrecondition();
+export function validate(scope: TScope, context: TContext): void {
+  const branch = currentBranchPrecondition(context);
   switch (scope) {
     case 'UPSTACK':
-      validateBranchUpstackInclusive(branch);
+      validateBranchUpstackInclusive(branch, context);
       break;
     case 'DOWNSTACK':
-      validateBranchDownstackInclusive(branch);
+      validateBranchDownstackInclusive(branch, context);
       break;
     case 'FULLSTACK':
-      validateBranchFullstack(branch);
+      validateBranchFullstack(branch, context);
       break;
   }
   logInfo(`Current stack is valid`);
 }
 
-function validateBranchFullstack(branch: Branch): void {
-  const metaStack = new MetaStackBuilder().fullStackFromBranch(branch);
-  const gitStack = new GitStackBuilder().fullStackFromBranch(branch);
+function validateBranchFullstack(branch: Branch, context: TContext): void {
+  const metaStack = new MetaStackBuilder().fullStackFromBranch(branch, context);
+  const gitStack = new GitStackBuilder().fullStackFromBranch(branch, context);
 
   compareStacks(metaStack, gitStack);
 }
 
-function validateBranchDownstackInclusive(branch: Branch): void {
-  const metaStack = new MetaStackBuilder().downstackFromBranch(branch);
-  const gitStack = new GitStackBuilder().downstackFromBranch(branch);
+function validateBranchDownstackInclusive(
+  branch: Branch,
+  context: TContext
+): void {
+  const metaStack = new MetaStackBuilder().downstackFromBranch(branch, context);
+  const gitStack = new GitStackBuilder().downstackFromBranch(branch, context);
 
   compareStacks(metaStack, gitStack);
 }
 
-function validateBranchUpstackInclusive(branch: Branch): void {
+function validateBranchUpstackInclusive(
+  branch: Branch,
+  context: TContext
+): void {
   const metaStack =
-    new MetaStackBuilder().upstackInclusiveFromBranchWithParents(branch);
+    new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
+      branch,
+      context
+    );
   const gitStack = new GitStackBuilder().upstackInclusiveFromBranchWithParents(
-    branch
+    branch,
+    context
   );
   metaStack.source.parent = undefined;
   gitStack.source.parent = undefined;

--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -1,15 +1,20 @@
 import yargs, { Arguments } from 'yargs';
+import { initContext } from '../lib/context/context';
 import Branch from '../wrapper-classes/branch';
 
 yargs.completion('completion', (current, argv) => {
+  const context = initContext();
   const branchArg = getBranchArg(current, argv);
   if (branchArg === null) {
     return;
   }
 
-  return Branch.allBranchesWithFilter({
-    filter: (b) => b.name.startsWith(branchArg),
-  })
+  return Branch.allBranchesWithFilter(
+    {
+      filter: (b) => b.name.startsWith(branchArg),
+    },
+    context
+  )
     .map((b) => b.name)
     .sort();
 });

--- a/src/commands/branch-commands/bottom.ts
+++ b/src/commands/branch-commands/bottom.ts
@@ -17,9 +17,13 @@ export const description =
   "If you're in a stack: Branch A → Branch B → Branch C (you are here), checkout the branch at the bottom of the stack (Branch A).";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await switchBranchAction(TraversalDirection.Bottom, {
-      interactive: execStateConfig.interactive(),
-    });
+  return profile(argv, canonical, async (context) => {
+    await switchBranchAction(
+      TraversalDirection.Bottom,
+      {
+        interactive: execStateConfig.interactive(),
+      },
+      context
+    );
   });
 };

--- a/src/commands/branch-commands/checkout.ts
+++ b/src/commands/branch-commands/checkout.ts
@@ -20,11 +20,11 @@ export const aliases = ['co'];
 export const builder = args;
 
 export const handler = async (args: argsT): Promise<void> => {
-  return profile(args, canonical, async () => {
+  return profile(args, canonical, async (context) => {
     if (args.branch) {
       gpExecSync({ command: `git checkout ${args.branch}` });
     } else {
-      await interactiveCheckout();
+      await interactiveCheckout(context);
     }
   });
 };

--- a/src/commands/branch-commands/children.ts
+++ b/src/commands/branch-commands/children.ts
@@ -12,10 +12,10 @@ export const description =
   'Show the child branches of your current branch (i.e. directly above the current branch in the stack) as tracked by Graphite. Branch location metadata is stored under `.git/refs/branch-metadata`.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    const branch = currentBranchPrecondition();
+  return profile(argv, canonical, async (context) => {
+    const branch = currentBranchPrecondition(context);
 
-    const children = branch.getChildrenFromMeta();
+    const children = branch.getChildrenFromMeta(context);
     if (children.length === 0) {
       logInfo(
         `(${branch}) has no child branches (branches stacked on top of it).`

--- a/src/commands/branch-commands/create.ts
+++ b/src/commands/branch-commands/create.ts
@@ -33,11 +33,14 @@ export const description =
   'Create a new branch stacked on top of the current branch and commit staged changes. If no branch name is specified but a commit message is passed, generate a branch name from the commit message.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await createBranchAction({
-      branchName: argv.name,
-      commitMessage: argv['commit-message'],
-      addAll: argv['add-all'],
-    });
+  return profile(argv, canonical, async (context) => {
+    await createBranchAction(
+      {
+        branchName: argv.name,
+        commitMessage: argv['commit-message'],
+        addAll: argv['add-all'],
+      },
+      context
+    );
   });
 };

--- a/src/commands/branch-commands/next.ts
+++ b/src/commands/branch-commands/next.ts
@@ -25,10 +25,14 @@ export const description =
   "If you're in a stack, i.e. Branch A → Branch B (you are here) → Branch C, checkout the branch directly upstack (Branch C). If there are multiple child branches above in the stack, `gt next` will prompt you to choose which branch to checkout.  Pass the `steps` arg to checkout the branch `[steps]` levels above in the stack.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await switchBranchAction(TraversalDirection.Next, {
-      numSteps: argv.steps,
-      interactive: execStateConfig.interactive(),
-    });
+  return profile(argv, canonical, async (context) => {
+    await switchBranchAction(
+      TraversalDirection.Next,
+      {
+        numSteps: argv.steps,
+        interactive: execStateConfig.interactive(),
+      },
+      context
+    );
   });
 };

--- a/src/commands/branch-commands/parent.ts
+++ b/src/commands/branch-commands/parent.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
+import { TContext } from '../../lib/context/context';
 import {
   branchExistsPrecondition,
   currentBranchPrecondition,
@@ -29,14 +30,14 @@ export const description =
   'Show the parent branch of your current branch (i.e. directly below the current branch in the stack) as tracked by Graphite. Branch location metadata is stored under `.git/refs/branch-metadata`.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    const branch = currentBranchPrecondition();
+  return profile(argv, canonical, async (context) => {
+    const branch = currentBranchPrecondition(context);
     if (argv.set) {
-      setParent(branch, argv.set);
+      setParent(branch, argv.set, context);
     } else if (argv.reset) {
       branch.resetParentBranch();
     } else {
-      const parent = branch.getParentFromMeta();
+      const parent = branch.getParentFromMeta(context);
       if (parent) {
         console.log(parent.name);
       } else {
@@ -48,9 +49,9 @@ export const handler = async (argv: argsT): Promise<void> => {
   });
 };
 
-function setParent(branch: Branch, parent: string): void {
+function setParent(branch: Branch, parent: string, context: TContext): void {
   branchExistsPrecondition(parent);
-  const oldParent = branch.getParentFromMeta();
+  const oldParent = branch.getParentFromMeta(context);
   branch.setParentBranchName(parent);
   logInfo(
     `Updated (${branch}) parent from (${oldParent}) to (${chalk.green(parent)})`

--- a/src/commands/branch-commands/prev.ts
+++ b/src/commands/branch-commands/prev.ts
@@ -25,10 +25,14 @@ export const description =
   "If you're in a stack: Branch A → Branch B (you are here) → Branch C, checkout the branch directly downstack (Branch A). Pass the `steps` arg to checkout the branch `[steps]` levels below in the stack.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await switchBranchAction(TraversalDirection.Previous, {
-      numSteps: argv.steps,
-      interactive: execStateConfig.interactive(),
-    });
+  return profile(argv, canonical, async (context) => {
+    await switchBranchAction(
+      TraversalDirection.Previous,
+      {
+        numSteps: argv.steps,
+        interactive: execStateConfig.interactive(),
+      },
+      context
+    );
   });
 };

--- a/src/commands/branch-commands/rename.ts
+++ b/src/commands/branch-commands/rename.ts
@@ -25,11 +25,11 @@ export const description =
 export const builder = args;
 
 export const handler = async (args: argsT): Promise<void> => {
-  return profile(args, canonical, async () => {
-    const currentBranch = currentBranchPrecondition();
+  return profile(args, canonical, async (context) => {
+    const currentBranch = currentBranchPrecondition(context);
     const oldName = currentBranch.name;
     const newName = args['new-branch-name'];
-    const allBranches = Branch.allBranches();
+    const allBranches = Branch.allBranches(context);
 
     gpExecSync({ command: `git branch -m ${newName}` }, (err) => {
       throw new ExitFailedError(`Failed to rename the current branch.`, err);

--- a/src/commands/branch-commands/submit.ts
+++ b/src/commands/branch-commands/submit.ts
@@ -9,15 +9,18 @@ export const description =
 export const canonical = 'branch submit';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  await profile(argv, canonical, async () => {
-    await submitAction({
-      scope: 'BRANCH',
-      editPRFieldsInline: argv.edit,
-      draftToggle: argv.draft,
-      dryRun: argv['dry-run'],
-      updateOnly: argv['update-only'],
-      reviewers: argv.reviewers,
-    });
+  await profile(argv, canonical, async (context) => {
+    await submitAction(
+      {
+        scope: 'BRANCH',
+        editPRFieldsInline: argv.edit,
+        draftToggle: argv.draft,
+        dryRun: argv['dry-run'],
+        updateOnly: argv['update-only'],
+        reviewers: argv.reviewers,
+      },
+      context
+    );
     logTip(
       [
         `You submitted a pull request for a specific branch.`,

--- a/src/commands/branch-commands/sync.ts
+++ b/src/commands/branch-commands/sync.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
 import { getBranchTitle } from '../../actions/print_stack';
-import { repoConfig } from '../../lib/config';
 import { currentBranchPrecondition } from '../../lib/preconditions';
 import { syncPRInfoForBranches } from '../../lib/sync/pr_info';
 import { profile } from '../../lib/telemetry';
@@ -23,21 +22,21 @@ export const description =
   'Fetch GitHub PR information for the current branch.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canoncial, async () => {
-    const branch = currentBranchPrecondition();
+  return profile(argv, canoncial, async (context) => {
+    const branch = currentBranchPrecondition(context);
 
     if (argv.reset) {
       branch.clearPRInfo();
       return;
     }
 
-    await syncPRInfoForBranches([branch]);
+    await syncPRInfoForBranches([branch], context);
 
     const prInfo = branch.getPRInfo();
     if (prInfo === undefined) {
       logError(
         `Could not find associated PR. Please double-check that a PR exists on GitHub in repo ${chalk.bold(
-          repoConfig.getRepoName()
+          context.repoConfig.getRepoName()
         )} for the branch ${chalk.bold(branch.name)}.`
       );
       return;

--- a/src/commands/branch-commands/top.ts
+++ b/src/commands/branch-commands/top.ts
@@ -17,9 +17,13 @@ export const description =
   "If you're in a stack: Branch A → Branch B (you are here) → Branch C → Branch D , checkout the branch at the top of the stack (Branch D). If there are multiple parent branches in the stack, `gt branch top` will prompt you to choose which branch to checkout.";
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await switchBranchAction(TraversalDirection.Top, {
-      interactive: execStateConfig.interactive(),
-    });
+  return profile(argv, canonical, async (context) => {
+    await switchBranchAction(
+      TraversalDirection.Top,
+      {
+        interactive: execStateConfig.interactive(),
+      },
+      context
+    );
   });
 };

--- a/src/commands/commit-commands/amend.ts
+++ b/src/commands/commit-commands/amend.ts
@@ -33,11 +33,14 @@ export const description =
   'Amend the most recent commit and fix upstack branches.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await commitAmendAction({
-      message: argv.message,
-      noEdit: !argv.edit,
-      addAll: argv.all,
-    });
+  return profile(argv, canonical, async (context) => {
+    await commitAmendAction(
+      {
+        message: argv.message,
+        noEdit: !argv.edit,
+        addAll: argv.all,
+      },
+      context
+    );
   });
 };

--- a/src/commands/commit-commands/create.ts
+++ b/src/commands/commit-commands/create.ts
@@ -26,10 +26,13 @@ export const aliases = ['c'];
 export const description = 'Create a new commit and fix upstack branches.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await commitCreateAction({
-      message: argv.message,
-      addAll: argv.all,
-    });
+  return profile(argv, canonical, async (context) => {
+    await commitCreateAction(
+      {
+        message: argv.message,
+        addAll: argv.all,
+      },
+      context
+    );
   });
 };

--- a/src/commands/downstack-commands/edit.ts
+++ b/src/commands/downstack-commands/edit.ts
@@ -20,7 +20,10 @@ export const builder = args;
 export const aliases = ['e'];
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await editDownstack(argv.input ? { inputPath: argv.input } : undefined);
+  return profile(argv, canonical, async (context) => {
+    await editDownstack(
+      context,
+      argv.input ? { inputPath: argv.input } : undefined
+    );
   });
 };

--- a/src/commands/downstack-commands/submit.ts
+++ b/src/commands/downstack-commands/submit.ts
@@ -8,14 +8,17 @@ export const description =
 export const canonical = 'downstack submit';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  await profile(argv, canonical, async () => {
-    await submitAction({
-      scope: 'DOWNSTACK',
-      editPRFieldsInline: argv.edit,
-      draftToggle: argv.draft,
-      dryRun: argv['dry-run'],
-      updateOnly: argv['update-only'],
-      reviewers: argv.reviewers,
-    });
+  await profile(argv, canonical, async (context) => {
+    await submitAction(
+      {
+        scope: 'DOWNSTACK',
+        editPRFieldsInline: argv.edit,
+        draftToggle: argv.draft,
+        dryRun: argv['dry-run'],
+        updateOnly: argv['update-only'],
+        reviewers: argv.reviewers,
+      },
+      context
+    );
   });
 };

--- a/src/commands/downstack-commands/validate.ts
+++ b/src/commands/downstack-commands/validate.ts
@@ -12,7 +12,7 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    validate('DOWNSTACK');
+  return profile(argv, canonical, async (context) => {
+    validate('DOWNSTACK', context);
   });
 };

--- a/src/commands/feedback-commands/debug_context.ts
+++ b/src/commands/feedback-commands/debug_context.ts
@@ -30,17 +30,18 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv['recreate-from-file']) {
       const dir = recreateState(
-        fs.readFileSync(argv['recreate-from-file']).toString()
+        fs.readFileSync(argv['recreate-from-file']).toString(),
+        context
       );
       logInfo(`${chalk.green(dir)}`);
     } else if (argv.recreate) {
-      const dir = recreateState(argv.recreate);
+      const dir = recreateState(argv.recreate, context);
       logInfo(`${chalk.green(dir)}`);
     } else {
-      logInfo(captureState());
+      logInfo(captureState(context));
     }
   });
 };

--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -31,7 +31,7 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     const user = getUserEmail();
     if (!argv.message) {
       return;
@@ -42,7 +42,9 @@ export const handler = async (argv: argsT): Promise<void> => {
       {
         user: user || 'NotFound',
         message: argv.message,
-        debugContext: argv['with-debug-context'] ? captureState() : undefined,
+        debugContext: argv['with-debug-context']
+          ? captureState(context)
+          : undefined,
       }
     );
     if (response._response.status == 200) {

--- a/src/commands/log-commands/short.ts
+++ b/src/commands/log-commands/short.ts
@@ -12,7 +12,7 @@ export const canonical = 'log short';
 
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await logShortAction();
+  return profile(argv, canonical, async (context) => {
+    await logShortAction(context);
   });
 };

--- a/src/commands/repo-commands/ignored_branches.ts
+++ b/src/commands/repo-commands/ignored_branches.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { gpExecSync, logInfo, logWarn } from '../../lib/utils';
 
@@ -28,7 +27,7 @@ export const description =
   'Often branches that you never plan to create PRs and merge into trunk.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.add) {
       const foundBranches = findMatches(argv.add);
       if (foundBranches.length) {
@@ -43,17 +42,17 @@ export const handler = async (argv: argsT): Promise<void> => {
           `No branches were found matching the provided pattern. Please make sure it is correct.`
         );
       }
-      repoConfig.addIgnoreBranchPatterns([argv.add]);
+      context.repoConfig.addIgnoreBranchPatterns([argv.add]);
       logInfo(`Added (${argv.add}) to be ignored`);
     } else if (argv.remove) {
-      if (repoConfig.getIgnoreBranches().includes(argv.remove)) {
-        repoConfig.removeIgnoreBranches(argv.remove);
+      if (context.repoConfig.getIgnoreBranches().includes(argv.remove)) {
+        context.repoConfig.removeIgnoreBranches(argv.remove);
         logInfo(`Removed pattern (${argv.remove}) from ignore list`);
       } else {
         logInfo(`No pattern matching (${argv.remove}) found.`);
       }
     } else {
-      const ignoredBranches = repoConfig.getIgnoreBranches();
+      const ignoredBranches = context.repoConfig.getIgnoreBranches();
       if (ignoredBranches.length) {
         logInfo(`The following patterns are being ignored by Graphite:`);
         logInfo(ignoredBranches.join('\n'));

--- a/src/commands/repo-commands/max_branch_length.ts
+++ b/src/commands/repo-commands/max_branch_length.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { logInfo } from '../../lib/utils';
 
@@ -21,11 +20,11 @@ export const description =
   'Graphite will track up to this many commits on a branch. e.g. If this is set to 50, Graphite can track branches up to 50 commits long. Increasing this setting may result in slower performance for Graphite.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
-      repoConfig.update((data) => (data.maxBranchLength = argv.set));
+      context.repoConfig.update((data) => (data.maxBranchLength = argv.set));
     } else {
-      logInfo(`${repoConfig.getMaxBranchLength.toString()} commits`);
+      logInfo(`${context.repoConfig.getMaxBranchLength.toString()} commits`);
     }
   });
 };

--- a/src/commands/repo-commands/max_days_behind_trunk.ts
+++ b/src/commands/repo-commands/max_days_behind_trunk.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { logInfo } from '../../lib/utils';
 
@@ -21,11 +20,13 @@ export const description =
   'Graphite will track branches that lag up to this many days behind trunk. e.g. If this is set to 90, Graphite log/Graphite stacks commands will show all stacks up to 90 days behind trunk.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
-      repoConfig.update((data) => (data.maxDaysShownBehindTrunk = argv.set));
+      context.repoConfig.update(
+        (data) => (data.maxDaysShownBehindTrunk = argv.set)
+      );
     } else {
-      logInfo(repoConfig.getMaxDaysShownBehindTrunk().toString());
+      logInfo(context.repoConfig.getMaxDaysShownBehindTrunk().toString());
     }
   });
 };

--- a/src/commands/repo-commands/max_stacks_behind_trunk.ts
+++ b/src/commands/repo-commands/max_stacks_behind_trunk.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { logInfo } from '../../lib/utils';
 
@@ -21,11 +20,13 @@ export const description =
   'Graphite will track up to this many stacks that lag behind trunk. e.g. If this is set to 5, Graphite log/Graphite stacks commands will only show the first 5 stacks behind trunk.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
-      repoConfig.update((data) => (data.maxStacksShownBehindTrunk = argv.set));
+      context.repoConfig.update(
+        (data) => (data.maxStacksShownBehindTrunk = argv.set)
+      );
     } else {
-      logInfo(repoConfig.getMaxStacksShownBehindTrunk().toString());
+      logInfo(context.repoConfig.getMaxStacksShownBehindTrunk().toString());
     }
   });
 };

--- a/src/commands/repo-commands/repo_init.ts
+++ b/src/commands/repo-commands/repo_init.ts
@@ -26,7 +26,7 @@ export const description =
   'Create or regenerate a `.graphite_repo_config` file.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await init(argv.trunk, argv['ignore-branches']);
+  return profile(argv, canonical, async (context) => {
+    await init(context, argv.trunk, argv['ignore-branches']);
   });
 };

--- a/src/commands/repo-commands/repo_name.ts
+++ b/src/commands/repo-commands/repo_name.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { logInfo } from '../../lib/utils';
 
@@ -21,11 +20,11 @@ export const description =
   "The current repo's name stored in Graphite. e.g. in 'screenplaydev/graphite-cli', this is 'graphite-cli'.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
-      repoConfig.update((data) => (data.name = argv.set));
+      context.repoConfig.update((data) => (data.name = argv.set));
     } else {
-      logInfo(repoConfig.getRepoName());
+      logInfo(context.repoConfig.getRepoName());
     }
   });
 };

--- a/src/commands/repo-commands/repo_owner.ts
+++ b/src/commands/repo-commands/repo_owner.ts
@@ -1,5 +1,4 @@
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { profile } from '../../lib/telemetry';
 import { logInfo } from '../../lib/utils';
 
@@ -21,11 +20,11 @@ export const description =
   "The current repo owner's name stored in Graphite. e.g. in 'screenplaydev/graphite-cli', this is 'screenplaydev'.";
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
-      repoConfig.update((data) => (data.owner = argv.set));
+      context.repoConfig.update((data) => (data.owner = argv.set));
     } else {
-      logInfo(repoConfig.getRepoOwner());
+      logInfo(context.repoConfig.getRepoOwner());
     }
   });
 };

--- a/src/commands/repo-commands/repo_sync.ts
+++ b/src/commands/repo-commands/repo_sync.ts
@@ -54,14 +54,17 @@ export const description =
   'Delete any branches that have been merged or squashed into the trunk branch, and recursively check for stack states against main.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await syncAction({
-      pull: argv.pull,
-      force: argv.force,
-      resubmit: argv.resubmit,
-      delete: argv.delete,
-      showDeleteProgress: argv['show-delete-progress'],
-      fixDanglingBranches: argv['show-dangling'],
-    });
+  return profile(argv, canonical, async (context) => {
+    await syncAction(
+      {
+        pull: argv.pull,
+        force: argv.force,
+        resubmit: argv.resubmit,
+        delete: argv.delete,
+        showDeleteProgress: argv['show-delete-progress'],
+        fixDanglingBranches: argv['show-dangling'],
+      },
+      context
+    );
   });
 };

--- a/src/commands/repo-commands/repo_trunk.ts
+++ b/src/commands/repo-commands/repo_trunk.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { repoConfig } from '../../lib/config';
 import { branchExistsPrecondition } from '../../lib/preconditions';
 import { profile } from '../../lib/telemetry';
 import { getTrunk } from '../../lib/utils';
@@ -24,12 +23,12 @@ export const builder = args;
 
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.set) {
       branchExistsPrecondition(argv.set);
-      repoConfig.setTrunk(argv.set);
+      context.repoConfig.setTrunk(argv.set);
     } else {
-      console.log(`(${chalk.green(getTrunk())})`);
+      console.log(`(${chalk.green(getTrunk(context))})`);
     }
   });
 };

--- a/src/commands/stack-commands/fix.ts
+++ b/src/commands/stack-commands/fix.ts
@@ -27,15 +27,18 @@ export const builder = args;
 export const aliases = ['f'];
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
+  return profile(argv, canonical, async (context) => {
     if (argv.rebase && argv.regen) {
       throw new ExitFailedError(
         'Please specify either the "--rebase" or "--regen" method, not both'
       );
     }
-    await fixAction({
-      action: argv.rebase ? 'rebase' : argv.regen ? 'regen' : undefined,
-      mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
-    });
+    await fixAction(
+      {
+        action: argv.rebase ? 'rebase' : argv.regen ? 'regen' : undefined,
+        mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
+      },
+      context
+    );
   });
 };

--- a/src/commands/stack-commands/submit.ts
+++ b/src/commands/stack-commands/submit.ts
@@ -8,14 +8,17 @@ export const description =
   'Idempotently force push all branches in the current stack to GitHub, creating or updating distinct pull requests for each.';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  await profile(argv, canonical, async () => {
-    await submitAction({
-      scope: 'FULLSTACK',
-      editPRFieldsInline: argv.edit,
-      draftToggle: argv.draft,
-      dryRun: argv['dry-run'],
-      updateOnly: argv['update-only'],
-      reviewers: argv.reviewers,
-    });
+  await profile(argv, canonical, async (context) => {
+    await submitAction(
+      {
+        scope: 'FULLSTACK',
+        editPRFieldsInline: argv.edit,
+        draftToggle: argv.draft,
+        dryRun: argv['dry-run'],
+        updateOnly: argv['update-only'],
+        reviewers: argv.reviewers,
+      },
+      context
+    );
   });
 };

--- a/src/commands/stack-commands/validate.ts
+++ b/src/commands/stack-commands/validate.ts
@@ -12,7 +12,7 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    validate('FULLSTACK');
+  return profile(argv, canonical, async (context) => {
+    validate('FULLSTACK', context);
   });
 };

--- a/src/commands/upstack-commands/onto.ts
+++ b/src/commands/upstack-commands/onto.ts
@@ -19,10 +19,13 @@ export const description =
 export const builder = args;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    await currentBranchOntoAction({
-      onto: argv.branch,
-      mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
-    });
+  return profile(argv, canonical, async (context) => {
+    await currentBranchOntoAction(
+      {
+        onto: argv.branch,
+        mergeConflictCallstack: 'TOP_OF_CALLSTACK_WITH_NOTHING_AFTER',
+      },
+      context
+    );
   });
 };

--- a/src/commands/upstack-commands/submit.ts
+++ b/src/commands/upstack-commands/submit.ts
@@ -8,14 +8,17 @@ export const description =
 export const canonical = 'upstack submit';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  await profile(argv, canonical, async () => {
-    await submitAction({
-      scope: 'UPSTACK',
-      editPRFieldsInline: argv.edit,
-      draftToggle: argv.draft,
-      dryRun: argv['dry-run'],
-      updateOnly: argv['update-only'],
-      reviewers: argv.reviewers,
-    });
+  await profile(argv, canonical, async (context) => {
+    await submitAction(
+      {
+        scope: 'UPSTACK',
+        editPRFieldsInline: argv.edit,
+        draftToggle: argv.draft,
+        dryRun: argv['dry-run'],
+        updateOnly: argv['update-only'],
+        reviewers: argv.reviewers,
+      },
+      context
+    );
   });
 };

--- a/src/commands/upstack-commands/validate.ts
+++ b/src/commands/upstack-commands/validate.ts
@@ -12,7 +12,7 @@ export const builder = args;
 export const canonical = 'upstack validate';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async () => {
-    validate('UPSTACK');
+  return profile(argv, canonical, async (context) => {
+    validate('UPSTACK', context);
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,20 +7,13 @@ import {
   processGlobalArgumentsMiddleware,
 } from './lib/global-arguments';
 import { passthrough } from './lib/passthrough';
-import { refreshPRInfoInBackground } from './lib/requests';
-import {
-  fetchUpgradePromptInBackground,
-  postTelemetryInBackground,
-} from './lib/telemetry';
+import { postTelemetryInBackground } from './lib/telemetry';
 import { postSurveyResponsesInBackground } from './lib/telemetry/survey/post_survey';
 import {
   logError,
   preprocessCommand,
   signpostDeprecatedCommands,
 } from './lib/utils';
-
-fetchUpgradePromptInBackground();
-refreshPRInfoInBackground();
 
 // We try to post the survey response right after the user takes it, but in
 // case they quit early or there's some error, we'll continue to try to post

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -3,7 +3,10 @@ import execStateConfig from './exec_state_config';
 import messageConfig, {
   readMessageConfigForTestingOnly,
 } from './message_config';
-import { getOwnerAndNameFromURLForTesting, repoConfig } from './repo_config';
+import {
+  getOwnerAndNameFromURLForTesting,
+  repoConfigFactory,
+} from './repo_config';
 import { getRepoRootPath } from './repo_root_path';
 import userConfig from './user_config';
 
@@ -11,7 +14,7 @@ export {
   messageConfig,
   readMessageConfigForTestingOnly,
   userConfig,
-  repoConfig,
+  repoConfigFactory,
   getOwnerAndNameFromURLForTesting,
   execStateConfig,
   cache,

--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -175,5 +175,3 @@ export function getOwnerAndNameFromURLForTesting(originURL: string): {
 } {
   return getOwnerAndNameFromURL(originURL);
 }
-
-export const repoConfig = repoConfigFactory.load(); // TODO upstack: remove this global instance

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -3,6 +3,7 @@ import {
   MergeConflictCallstackT,
   persistMergeConflictCallstack,
 } from '../config/merge_conflict_callstack_config';
+import { TContext } from '../context/context';
 
 class ExitError extends Error {}
 class ExitCancelledError extends ExitError {
@@ -68,10 +69,10 @@ class KilledError extends ExitError {
 }
 
 class SiblingBranchError extends ExitError {
-  constructor(branches: Branch[]) {
+  constructor(branches: Branch[], context: TContext) {
     super(
       [
-        `Multiple branches pointing to commit ${branches[0].ref()}.`,
+        `Multiple branches pointing to commit ${branches[0].ref(context)}.`,
         `Graphite cannot infer parent-child relationships between identical branches.`,
         `Please add a commit to one, or delete one to continue:`,
         ...branches.map((b) => `-> (${b.name})`),

--- a/src/lib/preconditions/index.ts
+++ b/src/lib/preconditions/index.ts
@@ -1,5 +1,6 @@
 import Branch from '../../wrapper-classes/branch';
-import { repoConfig, userConfig } from '../config';
+import { userConfig } from '../config';
+import { TContext } from '../context/context';
 import { PreconditionsFailedError } from '../errors';
 import {
   detectStagedChanges,
@@ -18,14 +19,14 @@ function addAllAvailableTip(): void {
   }
 }
 
-function currentBranchPrecondition(): Branch {
+function currentBranchPrecondition(context: TContext): Branch {
   const branch = Branch.getCurrentBranch();
   if (!branch) {
     throw new PreconditionsFailedError(
       `Cannot find current branch. Please ensure you're running this command atop a checked-out branch.`
     );
   }
-  if (repoConfig.branchIsIgnored(branch.name)) {
+  if (context.repoConfig.branchIsIgnored(branch.name)) {
     throw new PreconditionsFailedError(
       [
         `Cannot use graphite atop (${branch.name}) which is explicitly ignored in your repo config.`,

--- a/src/lib/telemetry/upgrade_prompt.ts
+++ b/src/lib/telemetry/upgrade_prompt.ts
@@ -5,7 +5,8 @@ import cp from 'child_process';
 import { getUserEmail, SHOULD_REPORT_TELEMETRY } from '.';
 import { version } from '../../../package.json';
 import { API_SERVER } from '../api';
-import { messageConfig, repoConfig } from '../config';
+import { messageConfig } from '../config';
+import { TContext } from '../context/context';
 import { logMessageFromGraphite } from '../utils';
 
 function printAndClearOldMessage(): void {
@@ -18,8 +19,8 @@ function printAndClearOldMessage(): void {
     messageConfig.setMessage(undefined);
   }
 }
-export function fetchUpgradePromptInBackground(): void {
-  if (!repoConfig.graphiteInitialized()) {
+export function fetchUpgradePromptInBackground(context: TContext): void {
+  if (!context.repoConfig.graphiteInitialized()) {
     return;
   }
 

--- a/src/lib/utils/single_commit.ts
+++ b/src/lib/utils/single_commit.ts
@@ -1,8 +1,12 @@
 import { Commit } from '../../wrapper-classes';
 import Branch from '../../wrapper-classes/branch';
+import { TContext } from '../context/context';
 
-export function getSingleCommitOnBranch(branch: Branch): Commit | null {
-  const commits = branch.getCommitSHAs();
+export function getSingleCommitOnBranch(
+  branch: Branch,
+  context: TContext
+): Commit | null {
+  const commits = branch.getCommitSHAs(context);
   if (commits.length !== 1) {
     return null;
   }

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -1,12 +1,12 @@
 import { execSync } from 'child_process';
-import { repoConfig } from '../lib/config';
 import { ExitFailedError, PreconditionsFailedError } from '../lib/errors';
 import {
   getBranchChildrenOrParentsFromGit,
   getRef,
-  otherBranchesWithSameCommit
+  otherBranchesWithSameCommit,
 } from '../lib/git-refs';
 import { getCommitterDate, getTrunk, gpExecSync, logDebug } from '../lib/utils';
+import { TContext } from './../lib/context/context';
 import Commit from './commit';
 import MetadataRef, { TBranchPRInfo, TMeta } from './metadata_ref';
 
@@ -42,11 +42,11 @@ export default class Branch {
     return this.name;
   }
 
-  stackByTracingMetaParents(branch?: Branch): string[] {
+  stackByTracingMetaParents(context: TContext, branch?: Branch): string[] {
     const curBranch = branch || this;
-    const metaParent = curBranch.getParentFromMeta();
+    const metaParent = curBranch.getParentFromMeta(context);
     if (metaParent) {
-      return this.stackByTracingMetaParents(metaParent).concat([
+      return this.stackByTracingMetaParents(context, metaParent).concat([
         curBranch.name,
       ]);
     } else {
@@ -54,11 +54,11 @@ export default class Branch {
     }
   }
 
-  stackByTracingGitParents(branch?: Branch): string[] {
+  stackByTracingGitParents(context: TContext, branch?: Branch): string[] {
     const curBranch = branch || this;
-    const gitParents = curBranch.getParentsFromGit();
+    const gitParents = curBranch.getParentsFromGit(context);
     if (gitParents.length === 1) {
-      return this.stackByTracingGitParents(gitParents[0]).concat([
+      return this.stackByTracingGitParents(context, gitParents[0]).concat([
         curBranch.name,
       ]);
     } else {
@@ -66,8 +66,8 @@ export default class Branch {
     }
   }
 
-  getParentFromMeta(): Branch | undefined {
-    if (this.name === getTrunk().name) {
+  getParentFromMeta(context: TContext): Branch | undefined {
+    if (this.name === getTrunk(context).name) {
       return undefined;
     }
 
@@ -99,7 +99,7 @@ export default class Branch {
     return new Branch(parentName);
   }
 
-  public getChildrenFromMeta(): Branch[] {
+  public getChildrenFromMeta(context: TContext): Branch[] {
     logDebug(`Meta Children (${this.name}): start`);
     if (this.shouldUseMemoizedResults) {
       if (memoizedMetaChildren === undefined) {
@@ -107,7 +107,7 @@ export default class Branch {
           `Meta Children (${this.name}): initialize memoization | finding all branches...`
         );
         const metaChildren: Record<string, Branch[]> = {};
-        const allBranches = Branch.allBranches({
+        const allBranches = Branch.allBranches(context, {
           useMemoizedResults: this.shouldUseMemoizedResults,
         });
 
@@ -139,29 +139,29 @@ export default class Branch {
       return memoizedMetaChildren[this.name] ?? [];
     }
 
-    const children = Branch.allBranches().filter(
+    const children = Branch.allBranches(context).filter(
       (b) => MetadataRef.getMeta(b.name)?.parentBranchName === this.name
     );
     logDebug(`Git Children (${this.name}): end`);
     return children;
   }
 
-  public isUpstreamOf(commitRef: string): boolean {
+  public isUpstreamOf(commitRef: string, context: TContext): boolean {
     const downstreamRef = gpExecSync({
       command: `git merge-base ${this.name} ${commitRef}`,
     })
       .toString()
       .trim();
 
-    return downstreamRef !== this.ref();
+    return downstreamRef !== this.ref(context);
   }
 
-  public ref(): string {
-    return getRef(this);
+  public ref(context: TContext): string {
+    return getRef(this, context);
   }
 
-  public getMetaMergeBase(): string | undefined {
-    const parent = this.getParentFromMeta();
+  public getMetaMergeBase(context: TContext): string | undefined {
+    const parent = this.getParentFromMeta(context);
     if (!parent) {
       return undefined;
     }
@@ -258,12 +258,15 @@ export default class Branch {
     );
   }
 
-  public isTrunk(): boolean {
-    return this.name === getTrunk().name;
+  public isTrunk(context: TContext): boolean {
+    return this.name === getTrunk(context).name;
   }
 
-  static async branchWithName(name: string): Promise<Branch> {
-    const branch = Branch.allBranches().find((b) => b.name === name);
+  static async branchWithName(
+    name: string,
+    context: TContext
+  ): Promise<Branch> {
+    const branch = Branch.allBranches(context).find((b) => b.name === name);
     if (!branch) {
       throw new Error(`Failed to find branch named ${name}`);
     }
@@ -288,7 +291,10 @@ export default class Branch {
     return name.length > 0 && name !== 'HEAD' ? new Branch(name) : null;
   }
 
-  private static allBranchesImpl(opts?: { sort?: '-committerdate' }): Branch[] {
+  private static allBranchesImpl(
+    context: TContext,
+    opts?: { sort?: '-committerdate' }
+  ): Branch[] {
     const sortString = opts?.sort === undefined ? '' : `--sort='${opts?.sort}'`;
     return execSync(
       `git for-each-ref --format='%(refname:short)' ${sortString} refs/heads/`
@@ -296,22 +302,30 @@ export default class Branch {
       .toString()
       .trim()
       .split('\n')
-      .filter((name) => name.length > 0 && !repoConfig.branchIsIgnored(name))
+      .filter(
+        (name) => name.length > 0 && !context.repoConfig.branchIsIgnored(name)
+      )
       .map((name) => new Branch(name));
   }
 
-  static allBranches(opts?: TBranchFilters): Branch[] {
-    return Branch.allBranchesWithFilter({
-      filter: () => true,
-      opts: opts,
-    });
+  static allBranches(context: TContext, opts?: TBranchFilters): Branch[] {
+    return Branch.allBranchesWithFilter(
+      {
+        filter: () => true,
+        opts: opts,
+      },
+      context
+    );
   }
 
-  static allBranchesWithFilter(args: {
-    filter: (branch: Branch) => boolean;
-    opts?: TBranchFilters;
-  }): Branch[] {
-    let branches = Branch.allBranchesImpl({
+  static allBranchesWithFilter(
+    args: {
+      filter: (branch: Branch) => boolean;
+      opts?: TBranchFilters;
+    },
+    context: TContext
+  ): Branch[] {
+    let branches = Branch.allBranchesImpl(context, {
       sort:
         args.opts?.maxDaysBehindTrunk !== undefined
           ? '-committerdate'
@@ -327,7 +341,7 @@ export default class Branch {
     if (maxDaysBehindTrunk) {
       const trunkUnixTimestamp = parseInt(
         getCommitterDate({
-          revision: getTrunk().name,
+          revision: getTrunk(context).name,
           timeFormat: 'UNIX_TIMESTAMP',
         })
       );
@@ -366,28 +380,36 @@ export default class Branch {
   }
 
   static async getAllBranchesWithoutParents(
+    context: TContext,
     opts?: TBranchFilters & {
       excludeTrunk?: boolean;
     }
   ): Promise<Branch[]> {
-    return this.allBranchesWithFilter({
-      filter: (branch) => {
-        if (opts?.excludeTrunk && branch.name === getTrunk().name) {
-          return false;
-        }
-        return branch.getParentsFromGit().length === 0;
+    return this.allBranchesWithFilter(
+      {
+        filter: (branch) => {
+          if (opts?.excludeTrunk && branch.name === getTrunk(context).name) {
+            return false;
+          }
+          return branch.getParentsFromGit(context).length === 0;
+        },
+        opts: opts,
       },
-      opts: opts,
-    });
+      context
+    );
   }
 
   static async getAllBranchesWithParents(
+    context: TContext,
     opts?: TBranchFilters
   ): Promise<Branch[]> {
-    return this.allBranchesWithFilter({
-      filter: (branch) => branch.getParentsFromGit().length > 0,
-      opts: opts,
-    });
+    return this.allBranchesWithFilter(
+      {
+        filter: (branch) => branch.getParentsFromGit(context).length > 0,
+        opts: opts,
+      },
+      context
+    );
   }
 
   public head(): Commit {
@@ -406,12 +428,16 @@ export default class Branch {
     );
   }
 
-  public getChildrenFromGit(): Branch[] {
+  public getChildrenFromGit(context: TContext): Branch[] {
     logDebug(`Git Children (${this.name}): start`);
-    const kids = getBranchChildrenOrParentsFromGit(this, {
-      direction: 'children',
-      useMemoizedResults: this.shouldUseMemoizedResults,
-    });
+    const kids = getBranchChildrenOrParentsFromGit(
+      this,
+      {
+        direction: 'children',
+        useMemoizedResults: this.shouldUseMemoizedResults,
+      },
+      context
+    );
 
     // In order to tacitly support those that use merge workflows, our logic
     // marks children it has visited - and short circuits - to avoid
@@ -432,15 +458,15 @@ export default class Branch {
     }
   }
 
-  public getParentsFromGit(): Branch[] {
+  public getParentsFromGit(context: TContext): Branch[] {
     if (
       // Current branch is trunk
-      this.name === getTrunk().name
+      this.name === getTrunk(context).name
       // Current branch shares
     ) {
       return [];
-    } else if (this.pointsToSameCommitAs(getTrunk())) {
-      return [getTrunk()];
+    } else if (this.pointsToSameCommitAs(getTrunk(context), context)) {
+      return [getTrunk(context)];
     }
 
     // In order to tacitly support those that use merge workflows, our logic
@@ -448,20 +474,24 @@ export default class Branch {
     // duplication. This means that the ordering of children must be consistent
     // between git and meta to ensure that our views of their stacks always
     // align.
-    return getBranchChildrenOrParentsFromGit(this, {
-      direction: 'parents',
-      useMemoizedResults: this.shouldUseMemoizedResults,
-    }).sort(this.sortBranchesAlphabetically);
+    return getBranchChildrenOrParentsFromGit(
+      this,
+      {
+        direction: 'parents',
+        useMemoizedResults: this.shouldUseMemoizedResults,
+      },
+      context
+    ).sort(this.sortBranchesAlphabetically);
   }
 
-  private pointsToSameCommitAs(branch: Branch): boolean {
-    return !!otherBranchesWithSameCommit(branch).find(
+  private pointsToSameCommitAs(branch: Branch, context: TContext): boolean {
+    return !!otherBranchesWithSameCommit(branch, context).find(
       (b) => b.name === branch.name
     );
   }
 
-  public branchesWithSameCommit(): Branch[] {
-    return otherBranchesWithSameCommit(this);
+  public branchesWithSameCommit(context: TContext): Branch[] {
+    return otherBranchesWithSameCommit(this, context);
   }
 
   public setPriorSubmitTitle(title: string): void {
@@ -519,8 +549,8 @@ export default class Branch {
     return this.getMeta()?.prInfo;
   }
 
-  public isBaseSameAsRemotePr(): boolean {
-    const parent = this.getParentFromMeta();
+  public isBaseSameAsRemotePr(context: TContext): boolean {
+    const parent = this.getParentFromMeta(context);
     if (parent === undefined) {
       throw new PreconditionsFailedError(
         `Could not find parent for branch ${this.name} to submit PR against. Please checkout ${this.name} and run \`gt upstack onto <parent_branch>\` to set its parent.`
@@ -530,12 +560,12 @@ export default class Branch {
   }
 
   // Due to deprecate in favor of other functions.
-  public getCommitSHAs(): string[] {
+  public getCommitSHAs(context: TContext): string[] {
     // We rely on meta here as the source of truth to handle the case where
     // the user has just created a new branch, but hasn't added any commits
     // - so both branch tips point to the same commit. Graphite knows that
     // this is a parent-child relationship, but git does not.
-    const parent = this.getParentFromMeta();
+    const parent = this.getParentFromMeta(context);
     if (parent === undefined) {
       return [];
     }

--- a/src/wrapper-classes/git_stack_builder.ts
+++ b/src/wrapper-classes/git_stack_builder.ts
@@ -1,30 +1,37 @@
 import { AbstractStackBuilder } from '.';
+import { TContext } from '../lib/context/context';
 import { MultiParentError, SiblingBranchError } from '../lib/errors';
 import Branch from './branch';
 
 export default class GitStackBuilder extends AbstractStackBuilder {
-  protected getBranchParent(branch: Branch): Branch | undefined {
-    return branch.getParentsFromGit()[0];
+  protected getBranchParent(
+    branch: Branch,
+    context: TContext
+  ): Branch | undefined {
+    return branch.getParentsFromGit(context)[0];
   }
 
-  protected getChildrenForBranch(branch: Branch): Branch[] {
-    this.checkSiblingBranches(branch);
-    return branch.getChildrenFromGit();
+  protected getChildrenForBranch(branch: Branch, context: TContext): Branch[] {
+    this.checkSiblingBranches(branch, context);
+    return branch.getChildrenFromGit(context);
   }
 
-  protected getParentForBranch(branch: Branch): Branch | undefined {
-    this.checkSiblingBranches(branch);
-    const parents = branch.getParentsFromGit();
+  protected getParentForBranch(
+    branch: Branch,
+    context: TContext
+  ): Branch | undefined {
+    this.checkSiblingBranches(branch, context);
+    const parents = branch.getParentsFromGit(context);
     if (parents.length > 1) {
       throw new MultiParentError(branch, parents);
     }
     return parents[0];
   }
 
-  private checkSiblingBranches(branch: Branch): void {
-    const siblingBranches = branch.branchesWithSameCommit();
+  private checkSiblingBranches(branch: Branch, context: TContext): void {
+    const siblingBranches = branch.branchesWithSameCommit(context);
     if (siblingBranches.length > 0) {
-      throw new SiblingBranchError([branch].concat(siblingBranches));
+      throw new SiblingBranchError([branch].concat(siblingBranches), context);
     }
   }
 }

--- a/src/wrapper-classes/meta_stack_builder.ts
+++ b/src/wrapper-classes/meta_stack_builder.ts
@@ -1,16 +1,23 @@
 import { AbstractStackBuilder } from '.';
+import { TContext } from '../lib/context/context';
 import Branch from './branch';
 
 export default class MetaStackBuilder extends AbstractStackBuilder {
-  protected getBranchParent(branch: Branch): Branch | undefined {
-    return branch.getParentFromMeta();
+  protected getBranchParent(
+    branch: Branch,
+    context: TContext
+  ): Branch | undefined {
+    return branch.getParentFromMeta(context);
   }
 
-  protected getChildrenForBranch(branch: Branch): Branch[] {
-    return branch.getChildrenFromMeta();
+  protected getChildrenForBranch(branch: Branch, context: TContext): Branch[] {
+    return branch.getChildrenFromMeta(context);
   }
 
-  protected getParentForBranch(branch: Branch): Branch | undefined {
-    return branch.getParentFromMeta();
+  protected getParentForBranch(
+    branch: Branch,
+    context: TContext
+  ): Branch | undefined {
+    return branch.getParentFromMeta(context);
   }
 }

--- a/test/fast/actions/submit_action.test.ts
+++ b/test/fast/actions/submit_action.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { execSync } from 'child_process';
 import { inferPRBody, inferPRTitle } from '../../../src/actions/submit';
+import { initContext } from '../../../src/lib/context/context';
 import Branch from '../../../src/wrapper-classes/branch';
 import { BasicScene } from '../../lib/scenes';
 import { configureTest } from '../../lib/utils';
@@ -8,6 +9,7 @@ import { configureTest } from '../../lib/utils';
 for (const scene of [new BasicScene()]) {
   describe(`(${scene}): correctly infers submit info from commits`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('can infer title/body from single commit', async () => {
       const title = 'Test Title';
@@ -18,10 +20,10 @@ for (const scene of [new BasicScene()]) {
       scene.repo.createChange('a');
       execSync(`git commit -m "${title}" -m "${body}"`);
 
-      const branch = await Branch.branchWithName('a');
+      const branch = await Branch.branchWithName('a', context);
 
-      expect(inferPRTitle(branch)).to.equals(title);
-      expect(inferPRBody(branch)).to.equals(body);
+      expect(inferPRTitle(branch, context)).to.equals(title);
+      expect(inferPRBody(branch, context)).to.equals(body);
     });
 
     it('can infer just title with no body', async () => {
@@ -31,9 +33,9 @@ for (const scene of [new BasicScene()]) {
       scene.repo.createChange('a');
       scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);
 
-      const branch = await Branch.branchWithName('a');
-      expect(inferPRTitle(branch)).to.equals(title);
-      expect(inferPRBody(branch)).to.be.null;
+      const branch = await Branch.branchWithName('a', context);
+      expect(inferPRTitle(branch, context)).to.equals(title);
+      expect(inferPRBody(branch, context)).to.be.null;
     });
 
     it('does not infer title/body for multiple commits', async () => {
@@ -44,9 +46,9 @@ for (const scene of [new BasicScene()]) {
       scene.repo.execCliCommand(`branch create "a" -m "${commitMessage}" -q`);
       scene.repo.createChangeAndCommit(commitMessage);
 
-      const branch = await Branch.branchWithName('a');
-      expect(inferPRTitle(branch)).to.not.equals(title);
-      expect(inferPRBody(branch)).to.be.null;
+      const branch = await Branch.branchWithName('a', context);
+      expect(inferPRTitle(branch, context)).to.not.equals(title);
+      expect(inferPRBody(branch, context)).to.be.null;
     });
   });
 }

--- a/test/fast/actions/validate_action.test.ts
+++ b/test/fast/actions/validate_action.test.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
 import { validate, validateStack } from '../../../src/actions/validate';
 import { cache } from '../../../src/lib/config';
+import { initContext } from '../../../src/lib/context/context';
+import { currentBranchPrecondition } from '../../../src/lib/preconditions';
+import { MetaStackBuilder, Stack } from '../../../src/wrapper-classes';
+import Branch from '../../../src/wrapper-classes/branch';
 import { allScenes, BasicScene, TrailingProdScene } from '../../lib/scenes';
 import { configureTest } from '../../lib/utils';
-import { MetaStackBuilder, Stack } from '../../../src/wrapper-classes';
-import { currentBranchPrecondition } from '../../../src/lib/preconditions';
-import Branch from '../../../src/wrapper-classes/branch';
 
 function setupScene(scene: BasicScene | TrailingProdScene) {
   scene.repo.createChange('a');
@@ -22,8 +23,10 @@ function setupScene(scene: BasicScene | TrailingProdScene) {
 }
 
 for (const scene of allScenes) {
+  // eslint-disable-next-line max-lines-per-function
   describe(`(${scene}): validate action`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('Can validate upstack', async () => {
       setupScene(scene);
@@ -31,36 +34,46 @@ for (const scene of allScenes) {
       let stack: Stack;
 
       scene.repo.checkoutBranch('a');
-      expect(() => validate('UPSTACK')).to.throw(Error);
-      branch = currentBranchPrecondition();
+      expect(() => validate('UPSTACK', context)).to.throw(Error);
+      branch = currentBranchPrecondition(context);
       stack = new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
-        branch
+        branch,
+        context
       );
-      expect(() => validateStack('UPSTACK', stack)).to.throw(Error);
+      expect(() => validateStack('UPSTACK', stack, context)).to.throw(Error);
 
       scene.repo.checkoutBranch('b');
-      expect(() => validate('UPSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
+      expect(() => validate('UPSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
       stack = new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
-        branch
+        branch,
+        context
       );
-      expect(() => validateStack('UPSTACK', stack)).to.not.throw(Error);
+      expect(() => validateStack('UPSTACK', stack, context)).to.not.throw(
+        Error
+      );
 
       scene.repo.checkoutBranch('c');
-      expect(() => validate('UPSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
+      expect(() => validate('UPSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
       stack = new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
-        branch
+        branch,
+        context
       );
-      expect(() => validateStack('UPSTACK', stack)).to.not.throw(Error);
+      expect(() => validateStack('UPSTACK', stack, context)).to.not.throw(
+        Error
+      );
 
       scene.repo.checkoutBranch('d');
-      expect(() => validate('UPSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
+      expect(() => validate('UPSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
       stack = new MetaStackBuilder().upstackInclusiveFromBranchWithParents(
-        branch
+        branch,
+        context
       );
-      expect(() => validateStack('UPSTACK', stack)).to.not.throw(Error);
+      expect(() => validateStack('UPSTACK', stack, context)).to.not.throw(
+        Error
+      );
     });
 
     it('Can validate downstack', async () => {
@@ -69,28 +82,36 @@ for (const scene of allScenes) {
       let metaStack: Stack;
 
       scene.repo.checkoutBranch('a');
-      expect(() => validate('DOWNSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().downstackFromBranch(branch);
-      expect(() => validateStack('DOWNSTACK', metaStack)).to.not.throw(Error);
+      expect(() => validate('DOWNSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().downstackFromBranch(branch, context);
+      expect(() => validateStack('DOWNSTACK', metaStack, context)).to.not.throw(
+        Error
+      );
 
       scene.repo.checkoutBranch('b');
-      expect(() => validate('DOWNSTACK')).to.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().downstackFromBranch(branch);
-      expect(() => validateStack('DOWNSTACK', metaStack)).to.throw(Error);
+      expect(() => validate('DOWNSTACK', context)).to.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().downstackFromBranch(branch, context);
+      expect(() => validateStack('DOWNSTACK', metaStack, context)).to.throw(
+        Error
+      );
 
       scene.repo.checkoutBranch('c');
-      expect(() => validate('DOWNSTACK')).to.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().downstackFromBranch(branch);
-      expect(() => validateStack('DOWNSTACK', metaStack)).to.throw(Error);
+      expect(() => validate('DOWNSTACK', context)).to.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().downstackFromBranch(branch, context);
+      expect(() => validateStack('DOWNSTACK', metaStack, context)).to.throw(
+        Error
+      );
 
       scene.repo.checkoutBranch('d');
-      expect(() => validate('DOWNSTACK')).to.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().downstackFromBranch(branch);
-      expect(() => validateStack('DOWNSTACK', metaStack)).to.throw(Error);
+      expect(() => validate('DOWNSTACK', context)).to.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().downstackFromBranch(branch, context);
+      expect(() => validateStack('DOWNSTACK', metaStack, context)).to.throw(
+        Error
+      );
     });
 
     it('Can validate fullstack', async () => {
@@ -99,26 +120,32 @@ for (const scene of allScenes) {
       scene.repo.createChange('a');
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
       cache.clearAll();
-      expect(() => validate('FULLSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().fullStackFromBranch(branch);
-      expect(() => validateStack('FULLSTACK', metaStack)).to.not.throw(Error);
+      expect(() => validate('FULLSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().fullStackFromBranch(branch, context);
+      expect(() => validateStack('FULLSTACK', metaStack, context)).to.not.throw(
+        Error
+      );
 
       scene.repo.createChange('b');
       scene.repo.execCliCommand(`branch create "b" -m "b" -q`);
       cache.clearAll();
-      expect(() => validate('FULLSTACK')).to.not.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().fullStackFromBranch(branch);
-      expect(() => validateStack('FULLSTACK', metaStack)).to.not.throw(Error);
+      expect(() => validate('FULLSTACK', context)).to.not.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().fullStackFromBranch(branch, context);
+      expect(() => validateStack('FULLSTACK', metaStack, context)).to.not.throw(
+        Error
+      );
 
       scene.repo.createAndCheckoutBranch('c');
       scene.repo.createChangeAndCommit('c');
       cache.clearAll();
-      expect(() => validate('FULLSTACK')).to.throw(Error);
-      branch = currentBranchPrecondition();
-      metaStack = new MetaStackBuilder().fullStackFromBranch(branch);
-      expect(() => validateStack('FULLSTACK', metaStack)).to.throw(Error);
+      expect(() => validate('FULLSTACK', context)).to.throw(Error);
+      branch = currentBranchPrecondition(context);
+      metaStack = new MetaStackBuilder().fullStackFromBranch(branch, context);
+      expect(() => validateStack('FULLSTACK', metaStack, context)).to.throw(
+        Error
+      );
     });
   });
 }

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { initContext } from '../../../../src/lib/context/context';
 import Branch from '../../../../src/wrapper-classes/branch';
 import { allScenes } from '../../../lib/scenes';
 import { configureTest } from '../../../lib/utils';
@@ -6,6 +7,7 @@ import { configureTest } from '../../../lib/utils';
 for (const scene of allScenes) {
   describe(`(${scene}): branch create`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('Can run branch create', () => {
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
@@ -52,14 +54,15 @@ for (const scene of allScenes) {
       scene.repo.createChange('2');
       scene.repo.execCliCommand("branch create a -m 'a'");
 
-      const branch = await Branch.branchWithName('a');
+      const branch = await Branch.branchWithName('a', context);
       branch.setPRInfo({
         number: 1,
         base: 'main',
       });
 
-      expect((await Branch.branchWithName('a')).getPRInfo() !== undefined).to.be
-        .true;
+      expect(
+        (await Branch.branchWithName('a', context)).getPRInfo() !== undefined
+      ).to.be.true;
 
       scene.repo.checkoutBranch('main');
       scene.repo.deleteBranch('a');
@@ -68,8 +71,9 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand("branch create a -m 'a'");
 
       // Upon recreating the branch, the old PR info should be gone.
-      expect((await Branch.branchWithName('a')).getPRInfo() === undefined).to.be
-        .true;
+      expect(
+        (await Branch.branchWithName('a', context)).getPRInfo() === undefined
+      ).to.be.true;
     });
   });
 }

--- a/test/fast/commands/stack/fix.test.ts
+++ b/test/fast/commands/stack/fix.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { initContext } from '../../../../src/lib/context/context';
 import Branch from '../../../../src/wrapper-classes/branch';
 import { allScenes } from '../../../lib/scenes';
 import { configureTest, expectCommits } from '../../../lib/utils';
@@ -7,6 +8,7 @@ for (const scene of allScenes) {
   // eslint-disable-next-line max-lines-per-function
   describe(`(${scene}): stack fix`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('Can fix a stack of three branches', () => {
       scene.repo.createChange('2', 'a');
@@ -91,8 +93,8 @@ for (const scene of allScenes) {
 
       const branch = new Branch('b');
 
-      expect(branch.stackByTracingMetaParents().join(',')).not.to.equal(
-        branch.stackByTracingGitParents().join(',')
+      expect(branch.stackByTracingMetaParents(context).join(',')).not.to.equal(
+        branch.stackByTracingGitParents(context).join(',')
       );
 
       scene.repo.checkoutBranch('a');
@@ -101,8 +103,8 @@ for (const scene of allScenes) {
 
       scene.repo.checkoutBranch('b');
 
-      expect(branch.stackByTracingMetaParents().join(',')).to.equal(
-        branch.stackByTracingGitParents().join(',')
+      expect(branch.stackByTracingMetaParents(context).join(',')).to.equal(
+        branch.stackByTracingGitParents(context).join(',')
       );
     });
 

--- a/test/fast/wrapper-classes/branch.test.ts
+++ b/test/fast/wrapper-classes/branch.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { initContext } from '../../../src/lib/context/context';
 import Branch from '../../../src/wrapper-classes/branch';
 import { allScenes } from '../../lib/scenes';
 import { configureTest } from '../../lib/utils';
@@ -6,13 +7,14 @@ import { configureTest } from '../../lib/utils';
 for (const scene of allScenes) {
   describe(`(${scene}): branch class`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('Can list git parent for a branch', () => {
       scene.repo.createChange('2');
       scene.repo.execCliCommand(`branch create a -m "a" -q`);
 
       const branch = new Branch('a');
-      expect(branch.getParentsFromGit()[0].name).to.equal('main');
+      expect(branch.getParentsFromGit(context)[0].name).to.equal('main');
     });
 
     it('Can list parent based on meta for a branch', () => {
@@ -20,8 +22,8 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
 
       const branch = new Branch('a');
-      expect(branch.getParentFromMeta()).is.not.undefined;
-      expect(branch.getParentFromMeta()?.name).to.equal('main');
+      expect(branch.getParentFromMeta(context)).is.not.undefined;
+      expect(branch.getParentFromMeta(context)?.name).to.equal('main');
     });
 
     it('Can fetch branches that point to the same commit', () => {
@@ -31,7 +33,7 @@ for (const scene of allScenes) {
       scene.repo.createAndCheckoutBranch('c');
       expect(
         new Branch('a')
-          .branchesWithSameCommit()
+          .branchesWithSameCommit(context)
           .map((b) => b.name)
           .sort()
           .join(', ')

--- a/test/fast/wrapper-classes/stack_builder.test.ts
+++ b/test/fast/wrapper-classes/stack_builder.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { initContext } from '../../../src/lib/context/context';
 import {
   GitStackBuilder,
   MetaStackBuilder,
@@ -12,6 +13,7 @@ for (const scene of allScenes) {
   // eslint-disable-next-line max-lines-per-function
   describe(`(${scene}): stack builder class`, function () {
     configureTest(this, scene);
+    const context = initContext();
 
     it('Can print stacks from git', () => {
       scene.repo.createAndCheckoutBranch('a');
@@ -27,8 +29,8 @@ for (const scene of allScenes) {
       scene.repo.createAndCheckoutBranch('d');
       scene.repo.createChangeAndCommit('d');
 
-      const gitStacks = new GitStackBuilder().allStacks();
-      const metaStacks = new MetaStackBuilder().allStacks();
+      const gitStacks = new GitStackBuilder().allStacks(context);
+      const metaStacks = new MetaStackBuilder().allStacks(context);
 
       expect(
         gitStacks[0].equals(
@@ -55,8 +57,8 @@ for (const scene of allScenes) {
       scene.repo.createChange('d');
       scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
 
-      const metaStacks = new MetaStackBuilder().allStacks();
-      const gitStacks = new GitStackBuilder().allStacks();
+      const metaStacks = new MetaStackBuilder().allStacks(context);
+      const gitStacks = new GitStackBuilder().allStacks(context);
 
       expect(
         metaStacks[0].equals(Stack.fromMap({ main: { d: {}, a: { b: {} } } }))
@@ -79,10 +81,12 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
 
       const metaStack = new MetaStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
       const gitStack = new GitStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
 
       expect(metaStack.equals(Stack.fromMap({ main: { a: { b: {} } } }))).to.be
@@ -103,10 +107,12 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
 
       const metaStack = new MetaStackBuilder().fullStackFromBranch(
-        new Branch('main')
+        new Branch('main'),
+        context
       );
       const gitStack = new GitStackBuilder().fullStackFromBranch(
-        new Branch('main')
+        new Branch('main'),
+        context
       );
 
       expect(metaStack.equals(Stack.fromMap({ main: { a: { b: {} }, d: {} } })))
@@ -122,10 +128,12 @@ for (const scene of allScenes) {
       scene.repo.createChangeAndCommit('b');
 
       const metaStack = new MetaStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
       const gitStack = new GitStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
 
       expect(metaStack.equals(Stack.fromMap({ main: { a: {} } }))).to.be.true;
@@ -140,10 +148,12 @@ for (const scene of allScenes) {
       scene.repo.createChange('c');
       scene.repo.execCliCommand(`branch create "c" -m "c" -q`);
       const metaStack = new MetaStackBuilder().downstackFromBranch(
-        new Branch('b')
+        new Branch('b'),
+        context
       );
       const gitStack = new GitStackBuilder().downstackFromBranch(
-        new Branch('b')
+        new Branch('b'),
+        context
       );
       expect(metaStack.equals(Stack.fromMap({ main: { a: { b: {} } } }))).to.be
         .true;
@@ -158,7 +168,8 @@ for (const scene of allScenes) {
       scene.repo.createChange('c');
       scene.repo.execCliCommand(`branch create "c" -m "c" -q`);
       const metaStack = new MetaStackBuilder().fullStackFromBranch(
-        new Branch('b')
+        new Branch('b'),
+        context
       );
       expect(
         metaStack
@@ -190,10 +201,12 @@ for (const scene of allScenes) {
       // A
 
       const metaStack = new MetaStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
       const gitStack = new GitStackBuilder().fullStackFromBranch(
-        new Branch('a')
+        new Branch('a'),
+        context
       );
 
       expect(metaStack.equals(Stack.fromMap({ main: { a: { b: {}, c: {} } } })))


### PR DESCRIPTION
**Context:**
Thread a context object containing the repo config through nearly every function in the cli.

This is an annoying refactor, but starts reducing our pervasive dependency on global configs, which make things hard to test, and create race conditions around edge cases that modify the configs.

After this change, I'll more more of our configurations into the context.
