### PR TITLE
refactor(survey_config): dont use global

### DIFF
--- a/src/lib/config/survey_config.ts
+++ b/src/lib/config/survey_config.ts
@@ -1,119 +1,87 @@
 import graphiteCLIRoutes from '@withgraphite/graphite-cli-routes';
+import * as t from '@withgraphite/retype';
 import { request } from '@withgraphite/retyped-routes';
-import fs from 'fs-extra';
-import os from 'os';
-import path from 'path';
 import { API_SERVER } from '../api';
 import { cliAuthPrecondition } from '../preconditions';
-import { SurveyResponseT } from '../telemetry/survey/survey';
+import { composeConfig } from './compose_config';
 
-const SURVEY_CONFIG_NAME = '.graphite_beta_survey';
-const SURVEY_CONFIG_PATH = path.join(os.homedir(), SURVEY_CONFIG_NAME);
+const surveyConfigSchema = t.shape({
+  responses: t.optional(
+    t.shape({
+      timestamp: t.number,
+      responses: t.array(t.shape({ question: t.string, answer: t.string })),
+      exitedEarly: t.boolean,
+    })
+  ),
+  postingResponse: t.boolean,
+});
 
-type TSurveyConfig = {
-  responses: SurveyResponseT | undefined;
-  postingResponse: boolean;
-};
+export type TSurveyResponse = NonNullable<
+  t.TypeOf<typeof surveyConfigSchema>['responses']
+>;
 
-class SurveyConfig {
-  _data: TSurveyConfig;
+export const surveyConfigFactory = composeConfig({
+  schema: surveyConfigSchema,
+  defaultLocations: [
+    {
+      relativePath: '.graphite_beta_survey',
+      relativeTo: 'USER_HOME',
+    },
+  ],
+  initialize: () => {
+    return {
+      responses: undefined,
+      postingResponse: false,
+    };
+  },
+  helperFunctions: (data, update) => {
+    return {
+      setSurveyResponses: (responses: TSurveyResponse): void => {
+        update((data) => (data.responses = responses));
+      },
+      hasSurveyResponse: (): boolean => data.responses !== undefined,
+      clearPriorSurveyResponses: (): void => {
+        update((data) => (data.responses = undefined));
+      },
+      postResponses: async (): Promise<boolean> => {
+        try {
+          const surveyResponse = data.responses;
+          if (surveyResponse === undefined) {
+            return false;
+          }
 
-  constructor(data: TSurveyConfig) {
-    this._data = data;
-  }
+          const authToken = cliAuthPrecondition();
 
-  public setSurveyResponses(responses: SurveyResponseT): void {
-    this._data.responses = responses;
-    this.save();
-  }
+          const response = await request.requestWithArgs(
+            API_SERVER,
+            graphiteCLIRoutes.surveyResponse,
+            {
+              authToken: authToken,
+              responses: {
+                timestamp: surveyResponse.timestamp,
+                responses: surveyResponse.responses.map((qa) => {
+                  return {
+                    question: qa.question,
+                    response: qa.answer,
+                  };
+                }),
+                exitedEarly: surveyResponse.exitedEarly,
+              },
+            }
+          );
 
-  public hasSurveyResponse(): boolean {
-    return this._data.responses !== undefined;
-  }
-
-  public clearPriorSurveyResponse(): void {
-    this._data.responses = undefined;
-    this.save();
-  }
-
-  public async postResponses(): Promise<boolean> {
-    try {
-      const surveyResponse = this._data.responses;
-      if (surveyResponse === undefined) {
-        return false;
-      }
-
-      const authToken = cliAuthPrecondition();
-
-      const response = await request.requestWithArgs(
-        API_SERVER,
-        graphiteCLIRoutes.surveyResponse,
-        {
-          authToken: authToken,
-          responses: {
-            timestamp: surveyResponse.timestamp,
-            responses: surveyResponse.responses.map((qa) => {
-              return {
-                question: qa.question,
-                response: qa.answer,
-              };
-            }),
-            exitedEarly: surveyResponse.exitedEarly,
-          },
+          if (response._response.status === 200) {
+            return true;
+          }
+        } catch (e) {
+          // Ignore any background errors posting the survey; if posting fails,
+          // then we'll try again the next time a user runs a CLI command.
         }
-      );
 
-      if (response._response.status === 200) {
-        return true;
-      }
-    } catch (e) {
-      // Ignore any background errors posting the survey; if posting fails,
-      // then we'll try again the next time a user runs a CLI command.
-    }
+        return false;
+      },
+    };
+  },
+});
 
-    return false;
-  }
-
-  public path(): string {
-    return SURVEY_CONFIG_PATH;
-  }
-
-  private save(): void {
-    if (this._data.responses !== undefined) {
-      fs.writeFileSync(SURVEY_CONFIG_PATH, JSON.stringify(this._data));
-      return;
-    }
-
-    // If we've reached this point, the survey config fields are empty - so we
-    // clean up the now unnecessary file.
-    SurveyConfig.delete();
-  }
-
-  static delete(): void {
-    if (fs.existsSync(SURVEY_CONFIG_PATH)) {
-      fs.unlinkSync(SURVEY_CONFIG_PATH);
-      return;
-    }
-  }
-}
-
-function readSurveyConfig(): SurveyConfig {
-  if (fs.existsSync(SURVEY_CONFIG_PATH)) {
-    const raw = fs.readFileSync(SURVEY_CONFIG_PATH);
-    try {
-      const parsedConfig = JSON.parse(raw.toString().trim()) as TSurveyConfig;
-      return new SurveyConfig(parsedConfig);
-    } catch (e) {
-      // There was some error so just silently clean up the file - hopefully
-      // we'll fix the malformed survey config on the next creation/save.
-      SurveyConfig.delete();
-    }
-  }
-  return new SurveyConfig({
-    responses: undefined,
-    postingResponse: false,
-  });
-}
-
-const surveyConfigSingleton = readSurveyConfig();
-export default surveyConfigSingleton;
+export const surveyConfig = surveyConfigFactory.load();

--- a/src/lib/telemetry/survey/post_survey.ts
+++ b/src/lib/telemetry/survey/post_survey.ts
@@ -1,5 +1,5 @@
 import cp from 'child_process';
-import surveyConfig from '../../config/survey_config';
+import { surveyConfig } from '../../config/survey_config';
 
 export function postSurveyResponsesInBackground(): void {
   // We don't worry about race conditions here - we can dedup on the server.
@@ -14,7 +14,7 @@ export function postSurveyResponsesInBackground(): void {
 export async function postSurveyResponse(): Promise<void> {
   const responsePostedSuccessfully = await surveyConfig.postResponses();
   if (responsePostedSuccessfully) {
-    surveyConfig.clearPriorSurveyResponse();
+    surveyConfig.clearPriorSurveyResponses();
   }
 }
 

--- a/src/lib/telemetry/survey/survey.ts
+++ b/src/lib/telemetry/survey/survey.ts
@@ -3,9 +3,10 @@ import { default as t } from '@withgraphite/retype';
 import { request } from '@withgraphite/retyped-routes';
 import prompts from 'prompts';
 import { API_SERVER } from '../../../lib/api';
-import surveyConfig from '../../../lib/config/survey_config';
+import { surveyConfig } from '../../../lib/config/survey_config';
 import { cliAuthPrecondition } from '../../../lib/preconditions';
 import { logMessageFromGraphite, logNewline } from '../../utils';
+import { TSurveyResponse } from './../../config/survey_config';
 import { postSurveyResponse } from './post_survey';
 
 export type SurveyT = t.UnwrapSchemaMap<
@@ -40,14 +41,8 @@ class ExitedSurveyError extends Error {
   }
 }
 
-export type SurveyResponseT = {
-  timestamp: number;
-  responses: { question: string; answer: string }[];
-  exitedEarly: boolean;
-};
-
 export async function showSurvey(survey: SurveyT): Promise<void> {
-  const responses: SurveyResponseT = {
+  const responses: TSurveyResponse = {
     timestamp: Date.now(),
     responses: [],
     exitedEarly: false,
@@ -106,7 +101,7 @@ async function askSurveyQuestions(args: {
         options: string[];
       }
   )[];
-  responses: SurveyResponseT;
+  responses: TSurveyResponse;
 }): Promise<void> {
   for (const [index, question] of args.questions.entries()) {
     const onCancel = {
@@ -167,7 +162,7 @@ async function askSurveyQuestions(args: {
 function assertUnreachable(arg: never): void {}
 
 async function logAnswers(args: {
-  responses: SurveyResponseT;
+  responses: TSurveyResponse;
   completionMessage: string | undefined;
 }): Promise<void> {
   surveyConfig.setSurveyResponses(args.responses);


### PR DESCRIPTION
**Context:**
Using the pattern started with RepoConfig, move SurveyConfig to a functional, retype based configuration. Upstack, we'll drop the global and move into the TContext object.
