### PR TITLE
fix(config): read configs from subdirs

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -63,3 +63,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPESCRIPT_DEFAULT_STYLE: prettier

--- a/src/lib/config/compose_config.ts
+++ b/src/lib/config/compose_config.ts
@@ -67,7 +67,7 @@ function configAbsolutePaths(
   defaultLocations: TDefaultConfigLocation[],
   defaultPathOverride?: string
 ): string[] {
-  const repoRoot = path.join(process.cwd(), getRepoRootPath());
+  const repoRoot = getRepoRootPath();
   const home = os.homedir();
   return (defaultPathOverride ? [defaultPathOverride] : []).concat(
     defaultLocations.map((l) =>

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -20,12 +20,12 @@ export default class GitRepo {
     }
   }
 
-  execCliCommand(command: string): void {
+  execCliCommand(command: string, opts?: { cwd?: string }): void {
     execSync(
       `NODE_ENV=development node ${__dirname}/../../../../dist/src/index.js ${command}`,
       {
         stdio: process.env.DEBUG ? 'inherit' : 'ignore',
-        cwd: this.dir,
+        cwd: opts?.cwd || this.dir,
       }
     );
   }

--- a/test/fast/commands/repo_config/repo_config.ts
+++ b/test/fast/commands/repo_config/repo_config.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import fs from 'fs-extra';
+import path from 'path';
 import { getOwnerAndNameFromURLForTesting } from '../../../../src/lib/config';
 import { BasicScene } from '../../../lib/scenes';
 import { configureTest } from '../../../lib/utils';
@@ -21,6 +23,15 @@ for (const scene of [new BasicScene()]) {
       );
       expect(owner === 'screenplaydev').to.be.true;
       expect(name === 'graphite-cli').to.be.true;
+    });
+
+    it('Can read the existing repo config when executing from a subfolder in the project', () => {
+      expect(() => scene.repo.execCliCommand(`ls`)).to.not.throw(Error);
+      const subDir = path.join(scene.dir, 'tmpDir');
+      fs.mkdirSync(subDir);
+      expect(() =>
+        scene.repo.execCliCommand(`ls`, { cwd: subDir })
+      ).to.not.throw(Error);
     });
 
     // Not sure where these are coming from but we should be able to handle


### PR DESCRIPTION
**Context:**
Fix a user reported bug where the repo config wasnt readable from subdirs of a repo. Add a regression test as well.
