### PR TITLE
fix(codeowners): change back to individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @withgraphite/eng
+* @gregorymfoster @nicholasyan @tomasreimers @goldjacobe


### PR DESCRIPTION
**Context:**
Github hasnt been picking up the team as a possible reviewer for the CLI despite this exact code owners working for monologue.
