### PR TITLE
refactor(survey): move config to context

### DIFF
--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -160,7 +160,7 @@ export async function submitAction(
   logNewline();
   const survey = await getSurvey();
   if (survey) {
-    await showSurvey(survey);
+    await showSurvey(survey, context);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,11 @@ import {
 } from './lib/global-arguments';
 import { passthrough } from './lib/passthrough';
 import { postTelemetryInBackground } from './lib/telemetry';
-import { postSurveyResponsesInBackground } from './lib/telemetry/survey/post_survey';
 import {
   logError,
   preprocessCommand,
   signpostDeprecatedCommands,
 } from './lib/utils';
-
-// We try to post the survey response right after the user takes it, but in
-// case they quit early or there's some error, we'll continue to try to post
-// it in the future until it succeeds.
-postSurveyResponsesInBackground();
 
 // https://www.npmjs.com/package/tmp#graceful-cleanup
 tmp.setGracefulCleanup();

--- a/src/lib/config/survey_config.ts
+++ b/src/lib/config/survey_config.ts
@@ -83,5 +83,3 @@ export const surveyConfigFactory = composeConfig({
     };
   },
 });
-
-export const surveyConfig = surveyConfigFactory.load();

--- a/src/lib/context/context.ts
+++ b/src/lib/context/context.ts
@@ -1,8 +1,13 @@
 import { repoConfigFactory } from './../config/repo_config';
+import { surveyConfigFactory } from './../config/survey_config';
 export type TContext = {
   repoConfig: ReturnType<typeof repoConfigFactory.load>;
+  surveyConfig: ReturnType<typeof surveyConfigFactory.load>;
 };
 
 export function initContext(): TContext {
-  return { repoConfig: repoConfigFactory.load() };
+  return {
+    repoConfig: repoConfigFactory.load(),
+    surveyConfig: surveyConfigFactory.load(),
+  };
 }

--- a/src/lib/telemetry/survey/post_survey.ts
+++ b/src/lib/telemetry/survey/post_survey.ts
@@ -1,9 +1,9 @@
 import cp from 'child_process';
-import { surveyConfig } from '../../config/survey_config';
+import { TContext } from '../../context/context';
 
-export function postSurveyResponsesInBackground(): void {
+export function postSurveyResponsesInBackground(context: TContext): void {
   // We don't worry about race conditions here - we can dedup on the server.
-  if (surveyConfig.hasSurveyResponse()) {
+  if (context.surveyConfig.hasSurveyResponse()) {
     cp.spawn('/usr/bin/env', ['node', __filename], {
       detached: true,
       stdio: 'ignore',
@@ -11,13 +11,9 @@ export function postSurveyResponsesInBackground(): void {
   }
 }
 
-export async function postSurveyResponse(): Promise<void> {
-  const responsePostedSuccessfully = await surveyConfig.postResponses();
+export async function postSurveyResponse(context: TContext): Promise<void> {
+  const responsePostedSuccessfully = await context.surveyConfig.postResponses();
   if (responsePostedSuccessfully) {
-    surveyConfig.clearPriorSurveyResponses();
+    context.surveyConfig.clearPriorSurveyResponses();
   }
-}
-
-if (process.argv[1] === __filename) {
-  void postSurveyResponse();
 }


### PR DESCRIPTION
**Context:**
Im working through all the configuration files in the CLI and moving them to an injected context object rather than having them globally accessed. This change in pattern improves testability and reduces race conditions.