### PR TITLE
lint(imports): unambigious rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "max-lines-per-function": ["error", { "max": 120 }],
     "@typescript-eslint/explicit-module-boundary-types": "error",
     "import/no-default-export": 2,
+    "import/unambiguous": 2,
     "no-restricted-syntax": [
       "error",
       {


### PR DESCRIPTION
**Context:**
Copy from server's eslint pattern. https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/unambiguous.md
