### PR TITLE
Update amend to pass message with quotes

### DIFF
--- a/src/actions/commit_amend.ts
+++ b/src/actions/commit_amend.ts
@@ -41,7 +41,7 @@ export async function commitAmendAction(
           opts.noEdit
             ? ['--no-edit']
             : opts.message
-            ? [`-m ${opts.message}`]
+            ? [`-m "${opts.message}"`]
             : [],
         ],
         ...[execStateConfig.noVerify() ? ['--no-verify'] : []],

--- a/test/fast/commands/commit/amend.test.ts
+++ b/test/fast/commands/commit/amend.test.ts
@@ -65,7 +65,6 @@ for (const scene of allScenes) {
     it("Can amend a commit with a multi-word commit message", () => {
       scene.repo.createChange("2");
       scene.repo.execCliCommand(`commit amend -m "a b c" -q`);
-      expect(scene.repo.currentBranchName()).to.equal("main");
       expectCommits(scene.repo, "a b c");
     });
   });

--- a/test/fast/commands/commit/amend.test.ts
+++ b/test/fast/commands/commit/amend.test.ts
@@ -62,10 +62,10 @@ for (const scene of allScenes) {
       expectCommits(scene.repo, 'b, a1, 1');
     });
 
-    it("Can amend a commit with a multi-word commit message", () => {
-      scene.repo.createChange("2");
+    it('Can amend a commit with a multi-word commit message', () => {
+      scene.repo.createChange('2');
       scene.repo.execCliCommand(`commit amend -m "a b c" -q`);
-      expectCommits(scene.repo, "a b c");
+      expectCommits(scene.repo, 'a b c');
     });
   });
 }

--- a/test/fast/commands/commit/amend.test.ts
+++ b/test/fast/commands/commit/amend.test.ts
@@ -61,5 +61,12 @@ for (const scene of allScenes) {
       // as we upstacked branch 'b' that commit 'a' was dropped.
       expectCommits(scene.repo, 'b, a1, 1');
     });
+
+    it("Can amend a commit with a multi-word commit message", () => {
+      scene.repo.createChange("2");
+      scene.repo.execCliCommand(`commit amend -m "a b c" -q`);
+      expect(scene.repo.currentBranchName()).to.equal("main");
+      expectCommits(scene.repo, "a b c");
+    });
   });
 }


### PR DESCRIPTION
**Context:**
Amend does not pass commit message with quotes. This is similar to https://github.com/withgraphite/graphite-cli/pull/375.

**Changes In This Pull Request:**
Add quotes around commit message passed to `gt commit amend`

**Test Plan:**
Added test based on https://github.com/withgraphite/graphite-cli/pull/375
