### PR TITLE
fix: allow backticks in commit title

### DIFF
--- a/src/lib/utils/commit.ts
+++ b/src/lib/utils/commit.ts
@@ -19,14 +19,17 @@ export function commit(opts: {
   noEdit?: boolean;
   rollbackOnError?: () => void;
 }): void {
+  // We must escape all backticks in the string
+  const message = opts.message?.replace(/`/g, '\\`');
+
   gpExecSync(
     {
       command: [
         'git commit',
         opts.amend ? `--amend` : '',
         opts.allowEmpty ? `--allow-empty` : '',
-        opts.message
-          ? `-m "${opts.message}"`
+        message
+          ? `-m "${message}"`
           : opts.allowEmpty
           ? `-t ${stringToTmpFileInput(EMPTY_COMMIT_MESSAGE_INFO)}`
           : '',


### PR DESCRIPTION
**Context:**
fish users should be able to use backticks in commit string (parity with git)

**Changes In This Pull Request:**



**Test Plan:**
tested using fish as shell

