### PR TITLE
fix(retype): dont log errors

### DIFF
--- a/src/lib/config/compose_config.ts
+++ b/src/lib/config/compose_config.ts
@@ -116,7 +116,7 @@ function readOrInitConfig<TConfigData>(
     ? JSON.parse(fs.readFileSync(configPath).toString())
     : initialize();
 
-  const validConfigFile = schema(rawConfig, { logFailures: true });
+  const validConfigFile = schema(rawConfig, { logFailures: false });
   if (!validConfigFile) {
     throw new ExitFailedError(`Malformed config file at ${configPath}`);
   }


### PR DESCRIPTION
**Context:**
If the config gets malformed, we're currently logging to many details - this is biting users around malformed merge_confict_continue configs. We should fix the root, but until then, let's reduce the scary messaging.
