### PR TITLE
fix: use pr number as source of truth for sync instead of branch name

### DIFF
--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -194,8 +194,7 @@ async function getValidBranchesToSubmit(
   } catch {
     throw new ValidationFailedError(`Validation failed. Will not submit.`);
   }
-  // Force a sync to link any PRs that have remote equivalents but weren't
-  // previously tracked with Graphite.
+
   await syncPRInfoForBranches(branchesToSubmit, context);
 
   return await processBranchesInInvalidState(branchesToSubmit);
@@ -272,7 +271,7 @@ async function submitPullRequests(
   context: TContext
 ) {
   if (!args.submissionInfoWithBranches.length) {
-    logInfo(`No eligible branches to create PRs for.`);
+    logInfo(`No eligible branches to create/update PRs for.`);
     logNewline();
     return;
   }

--- a/src/lib/sync/pr_info.ts
+++ b/src/lib/sync/pr_info.ts
@@ -29,10 +29,11 @@ export async function syncPRInfoForBranches(
       authToken: authToken,
       repoName: repoName,
       repoOwner: repoOwner,
-      prNumbers: [],
-      prHeadRefNames: branches
+      prNumbers: branches
         .filter((branch) => !branch.isTrunk(context))
-        .map((branch) => branch.name),
+        .map((branch) => branch.getPRInfo()?.number)
+        .filter((value): value is number => value !== undefined),
+      prHeadRefNames: [],
     }
   );
 


### PR DESCRIPTION
This brings us back to the old state of the world where we only sync branches that have been submitted on this machine.  This prevents the issue where branches with the same name as closed PRs would be deleted inadvertently and toward the world where graphite only operates on branches it knows about.

The future direction here is that this will correctly sync branches both submitted and retrieved with `gt get`