### PR TITLE
fix: add --no-ext-diff option to git diff invocations

### DIFF
--- a/src/actions/clean_branches.ts
+++ b/src/actions/clean_branches.ts
@@ -236,8 +236,9 @@ function branchMerged(branch: Branch, context: TContext): boolean {
   }
 
   const diffCheckProvesMerged =
-    execSync(`git diff ${branchName} ${trunk} | wc -l`).toString().trim() ===
-    '0';
+    execSync(`git diff --no-ext-diff ${branchName} ${trunk} | wc -l`)
+      .toString()
+      .trim() === '0';
   if (diffCheckProvesMerged) {
     return true;
   }

--- a/src/lib/utils/detect_staged_changes.ts
+++ b/src/lib/utils/detect_staged_changes.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 export function detectStagedChanges(): boolean {
   try {
-    execSync(`git diff --cached --exit-code`);
+    execSync(`git diff --no-ext-diff --cached --exit-code`);
   } catch {
     return true;
   }


### PR DESCRIPTION
User flagged a hanging issue when `git config diff.external`, which this flag skips, is set.