### PR TITLE
fix: issue with submit when filename and branch conflict

### DIFF
--- a/src/lib/utils/detect_unsubmitted_changes.ts
+++ b/src/lib/utils/detect_unsubmitted_changes.ts
@@ -6,7 +6,7 @@ export function detectUnsubmittedChanges(branch: Branch): boolean {
   return (
     gpExecSync(
       {
-        command: `git log ${branch.name} --not --remotes --simplify-by-decoration --decorate --oneline`,
+        command: `git log ${branch.name} --  --not --remotes --simplify-by-decoration --decorate --oneline`,
       },
       () => {
         throw new ExitFailedError(


### PR DESCRIPTION
was getting

```
fatal: ambiguous argument 'a': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

when trying to `gt ss` a branch sharing name w/ a file (for testing)
