### PR TITLE
Fix typo in `actions/submit/reviewers.ts`

### DIFF
--- a/src/actions/submit/reviewers.ts
+++ b/src/actions/submit/reviewers.ts
@@ -12,7 +12,7 @@ export async function getReviewers(args: {
       type: 'list',
       name: 'reviewers',
       message: 'Reviewers (comma-separated GitHub usernames)',
-      seperator: ',',
+      separator: ',',
     },
     {
       onCancel: () => {


### PR DESCRIPTION
I can't run `yarn build` locally without this change (TS error), no idea
how this has passed undetected for such a long time.

