### PR TITLE
fix: improve branch deletion error message and change force arg to -f

### DIFF
--- a/src/actions/log_short.ts
+++ b/src/actions/log_short.ts
@@ -152,7 +152,7 @@ function logRegenTip(context: TContext): void {
       `> gt branch checkout <branch> && gt upstack onto <parent> # fix a stack and update the parent`,
       `> gt branch checkout <branch> && gt stack fix --regen # generate stack based on current commit tree`,
       `> gt repo ignored-branches --add <branch> # set branch to be ignored by Graphite`,
-      `> git branch -D <branch> # delete branch from git`,
+      `> gt branch delete -f <branch> # delete branch from git`,
     ].join('\n'),
     context
   );

--- a/src/commands/branch-commands/delete.ts
+++ b/src/commands/branch-commands/delete.ts
@@ -1,6 +1,7 @@
 import yargs from 'yargs';
 import { deleteBranchAction } from '../../actions/delete_branch';
 import { profile } from '../../lib/telemetry';
+import { logTip } from '../../lib/utils';
 
 const args = {
   name: {
@@ -14,7 +15,7 @@ const args = {
     describe: `Force delete the git branch.`,
     demandOption: false,
     type: 'boolean',
-    alias: 'D',
+    alias: 'f',
     default: false,
   },
 } as const;
@@ -28,12 +29,13 @@ export const description =
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
   return profile(argv, canonical, async (context) => {
-    await deleteBranchAction(
-      {
-        branchName: argv.name,
-        force: argv.force,
-      },
-      context
-    );
+    if (!args.force) {
+      logTip(`You can force branch deletion with -f`, context);
+    }
+
+    await deleteBranchAction({
+      branchName: argv.name,
+      force: argv.force,
+    });
   });
 };

--- a/test/fast/commands/branch/branch_delete.test.ts
+++ b/test/fast/commands/branch/branch_delete.test.ts
@@ -19,7 +19,7 @@ for (const scene of allScenes) {
       expect(scene.repo.currentBranchName()).to.equal(branchName);
 
       scene.repo.checkoutBranch('main');
-      scene.repo.execCliCommand(`branch delete "${branchName}" -D -q`);
+      scene.repo.execCliCommand(`branch delete "${branchName}" -f -q`);
 
       expectBranches(scene.repo, 'main');
       expect(Branch.exists(branchName)).to.be.false;
@@ -38,7 +38,7 @@ for (const scene of allScenes) {
       scene.repo.createChangeAndCommit('2', '2');
 
       scene.repo.checkoutBranch('main');
-      scene.repo.execCliCommandAndGetOutput(`bdl "${branchName}" -D -q`);
+      scene.repo.execCliCommandAndGetOutput(`bdl "${branchName}" -f -q`);
 
       expectBranches(scene.repo, 'main');
       expect(Branch.exists(branchName)).to.be.false;

--- a/test/lib/utils/fake_squash_and_merge.ts
+++ b/test/lib/utils/fake_squash_and_merge.ts
@@ -5,7 +5,7 @@ export function fakeGitSquashAndMerge(
   repo: GitRepo,
   branchName: string,
   squashedCommitMessage: string
-) {
+): void {
   // Fake github squash and merge
   execSync(`git -C "${repo.dir}" switch -q -c temp ${branchName}`);
   repo.checkoutBranch('temp');


### PR DESCRIPTION
BEFORE:
```
error: The branch 'hello' is not fully merged.
If you are sure you want to delete it, run 'git branch -D hello'.
ERROR: Failed to delete branch. Aborting...
> Error: Command failed: git branch -d hello
> error: The branch 'hello' is not fully merged.
> If you are sure you want to delete it, run 'git branch -D hello'.
```

AFTER:
```
ERROR: Failed to delete branch. Aborting...
error: The branch 'asdf' is not fully merged.
If you are sure you want to delete it, run 'gt branch delete -f asdf'.
```
