### PR TITLE
feat: start tracking branch parent revision in meta

### DIFF
--- a/src/actions/create_branch.ts
+++ b/src/actions/create_branch.ts
@@ -56,7 +56,7 @@ export async function createBranchAction(
 
   // If the branch previously existed and the stale metadata is still around,
   // make sure that we wipe that stale metadata.
-  new Branch(branchName).clearMetadata().setParentBranchName(parentBranch.name);
+  Branch.create(branchName, parentBranch.name, parentBranch.getCurrentRef());
 
   if (isAddingEmptyCommit) {
     logInfo(

--- a/src/actions/fix.ts
+++ b/src/actions/fix.ts
@@ -317,7 +317,7 @@ function recursiveRegen(node: StackNode, context: TContext): void {
           oldParent?.name
         }) to (${chalk.green(newParent.name)})`
       );
-      branch.setParentBranchName(newParent.name);
+      branch.setParentBranch(newParent.name, newParent.getCurrentRef());
     }
   }
 

--- a/src/actions/onto/stack_onto.ts
+++ b/src/actions/onto/stack_onto.ts
@@ -90,7 +90,7 @@ export async function stackOntoBaseRebaseContinuation(
   cache.clearAll();
   // set current branch's parent only if the rebase succeeds.
   console.log(`setting ${currentBranch.name} parent to ${onto}`);
-  currentBranch.setParentBranchName(onto);
+  currentBranch.setParentBranch(onto, new Branch(onto).getCurrentRef());
 
   // Now perform a fix starting from the onto branch:
   const stackOntoContinuationFrame = {

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -23,6 +23,15 @@ export class Branch {
   name: string;
   shouldUseMemoizedResults: boolean;
 
+  static create(
+    branchName: string,
+    parentBranchName: string,
+    parentBranchRevision: string
+  ): void {
+    const branch = new Branch(branchName);
+    branch.writeMeta({ parentBranchName, parentBranchRevision });
+  }
+
   constructor(name: string, opts?: { useMemoizedResults: boolean }) {
     this.name = name;
     this.shouldUseMemoizedResults = opts?.useMemoizedResults || false;
@@ -235,6 +244,16 @@ export class Branch {
   public setParentBranchName(parentBranchName: string): void {
     const meta: TMeta = this.getMeta() || {};
     meta.parentBranchName = parentBranchName;
+    this.writeMeta(meta);
+  }
+
+  public setParentBranch(
+    parentBranchName: string,
+    parentBranchRevision: string
+  ): void {
+    const meta: TMeta = this.getMeta() || {};
+    meta.parentBranchName = parentBranchName;
+    meta.parentBranchRevision = parentBranchRevision;
     this.writeMeta(meta);
   }
 

--- a/src/wrapper-classes/metadata_ref.ts
+++ b/src/wrapper-classes/metadata_ref.ts
@@ -27,6 +27,7 @@ export type TBranchPriorSubmitInfo = {
 
 export type TMeta = {
   parentBranchName?: string;
+  parentBranchRevision?: string;
   prevRef?: string;
   prInfo?: TBranchPRInfo;
   priorSubmitInfo?: TBranchPriorSubmitInfo;


### PR DESCRIPTION
I was wrong about `prevRef` — that field does something different (tracks what the head of this branch was before, not what revision it was based on).  So we'll use a different field for tracking the base rev.
