### PR TITLE
fix: don't overwrite PR info fields on update

### DIFF
--- a/src/actions/submit/submit_prs.ts
+++ b/src/actions/submit/submit_prs.ts
@@ -136,7 +136,7 @@ function saveBranchPRInfo(prs: TSubmittedPR[], context: TContext): void {
   prs.forEach(async (pr) => {
     if (pr.response.status === 'updated' || pr.response.status === 'created') {
       const branch = await Branch.branchWithName(pr.response.head, context);
-      branch.setPRInfo({
+      branch.upsertPRInfo({
         number: pr.response.prNumber,
         url: pr.response.prURL,
         base: pr.request.base,

--- a/src/lib/sync/pr_info.ts
+++ b/src/lib/sync/pr_info.ts
@@ -58,7 +58,7 @@ async function syncHelper(
     await Promise.all(
       response.prs.map(async (pr) => {
         const branch = await Branch.branchWithName(pr.headRefName, context);
-        branch.setPRInfo({
+        branch.upsertPRInfo({
           number: pr.prNumber,
           base: pr.baseRefName,
           url: pr.url,

--- a/src/wrapper-classes/branch.ts
+++ b/src/wrapper-classes/branch.ts
@@ -533,9 +533,9 @@ export class Branch {
     return this.getMeta()?.priorSubmitInfo?.body;
   }
 
-  public setPRInfo(prInfo: TBranchPRInfo): void {
+  public upsertPRInfo(prInfo: TBranchPRInfo): void {
     const meta: TMeta = this.getMeta() || {};
-    meta.prInfo = prInfo;
+    meta.prInfo = { ...meta.prInfo, ...prInfo };
     this.writeMeta(meta);
   }
 

--- a/test/fast/commands/branch/branch_create.test.ts
+++ b/test/fast/commands/branch/branch_create.test.ts
@@ -53,7 +53,7 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand("branch create a -m 'a'");
 
       const branch = await Branch.branchWithName('a', scene.context);
-      branch.setPRInfo({
+      branch.upsertPRInfo({
         number: 1,
         base: 'main',
       });


### PR DESCRIPTION
I filed a linear to make the submit endpoint consistent with the prInfo endpoint, but for now this will do.
