### PR TITLE
feat: fix non-interactive submit

### DIFF
--- a/src/actions/submit/pr_draft.ts
+++ b/src/actions/submit/pr_draft.ts
@@ -1,7 +1,11 @@
 import prompts from 'prompts';
+import { execStateConfig } from '../../lib/config/exec_state_config';
 import { KilledError } from '../../lib/errors';
 
 export async function getPRDraftStatus(): Promise<boolean> {
+  if (!execStateConfig.interactive()) {
+    return true;
+  }
   const response = await prompts(
     {
       type: 'select',

--- a/src/actions/submit/submit.ts
+++ b/src/actions/submit/submit.ts
@@ -46,11 +46,17 @@ export async function submitAction(
   }
 
   if (!execStateConfig.interactive()) {
-    logInfo(
-      `Running in non-interactive mode. All new PRs will be created as draft and PR fields inline prompt will be silenced`
-    );
     args.editPRFieldsInline = false;
-    args.draftToggle = true;
+    args.reviewers = false;
+
+    logInfo(
+      `Running in non-interactive mode. Inline prompts to fill PR fields will be skipped${
+        args.draftToggle === undefined
+          ? ' and new PRs will be created in draft mode'
+          : ''
+      }.`
+    );
+    logNewline();
   }
 
   // Step 1: Validate

--- a/src/commands/shared-commands/submit.ts
+++ b/src/commands/shared-commands/submit.ts
@@ -21,7 +21,7 @@ export const command = 'submit';
 export const args = {
   draft: {
     describe:
-      'Creates new PRs in draft mode. If --no-interactive is true, this is automatically set to true.',
+      'If set, update draft status. If --no-interactive is true, new PRs will be created in draft mode.',
     type: 'boolean',
     alias: 'd',
   },


### PR DESCRIPTION
Big change here is to not un-publish submitted PRs.  Also ensures that we never prompt for reviewers in non-interactive mode even if `-r` is passed.