### PR TITLE
fix: direction of bco interactive

### DIFF
--- a/src/actions/interactive_checkout.ts
+++ b/src/actions/interactive_checkout.ts
@@ -17,13 +17,10 @@ type promptOptionT = { title: string; value: string };
 
 async function promptBranches(choices: promptOptionT[]): Promise<void> {
   const currentBranch = Branch.getCurrentBranch();
-  let currentBranchIndex: undefined | number = undefined;
 
-  if (currentBranch) {
-    currentBranchIndex = choices
-      .map((c) => c.value)
-      .indexOf(currentBranch.name);
-  }
+  const currentBranchIndex = currentBranch
+    ? choices.map((c) => c.value).indexOf(currentBranch.name)
+    : undefined;
 
   const chosenBranch = (
     await prompts(

--- a/src/wrapper-classes/stack.ts
+++ b/src/wrapper-classes/stack.ts
@@ -17,16 +17,13 @@ export class Stack {
   }
 
   public toPromptChoices(indent = 0): { title: string; value: string }[] {
-    let choices = [
-      {
-        title: `${'  '.repeat(indent)}↳ (${this.source.branch.name})`,
-        value: this.source.branch.name,
-      },
-    ];
-    this.source.children.forEach((c) => {
-      choices = choices.concat(new Stack(c).toPromptChoices(indent + 1));
-    });
-    return choices;
+    const currentChoice = {
+      title: `${'  '.repeat(indent)}↱ (${this.source.branch.name})`,
+      value: this.source.branch.name,
+    };
+    return this.source.children
+      .map((c) => new Stack(c).toPromptChoices(indent + 1))
+      .reduceRight((acc, arr) => arr.concat(acc), [currentChoice]);
   }
 
   public toString(): string {


### PR DESCRIPTION
![Screen Shot 2022-04-30 at 14.46.34.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/t6FDnC5t98Dwamvf2BHI/2d4b1953-53b7-4357-bb47-3e426f414d21/Screen%20Shot%202022-04-30%20at%2014.46.34.png)

Now matches `gt ls`
