### PR TITLE
refactor: clean up validation some more

### DIFF
--- a/src/actions/submit/validate_branches.ts
+++ b/src/actions/submit/validate_branches.ts
@@ -1,11 +1,7 @@
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { TContext } from '../../lib/context';
-import {
-  KilledError,
-  PreconditionsFailedError,
-  ValidationFailedError,
-} from '../../lib/errors';
+import { KilledError, PreconditionsFailedError } from '../../lib/errors';
 import { isEmptyBranch } from '../../lib/git/is_empty_branch';
 import { currentBranchPrecondition } from '../../lib/preconditions';
 import { syncPRInfoForBranches } from '../../lib/sync/pr_info';
@@ -42,11 +38,7 @@ function getAllBranchesToSubmit(
     return [currentBranchPrecondition()];
   }
 
-  try {
-    return validate(scope, context);
-  } catch {
-    throw new ValidationFailedError(`Validation failed. Will not submit.`);
-  }
+  return validate(scope, context);
 }
 
 function hasAnyMergedBranches(

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -17,15 +17,7 @@ export function validate(scope: TScope, context: TContext): Branch[] {
   );
 
   if (!metaStack.equals(gitStack)) {
-    throw new ValidationFailedError(
-      [
-        `Graphite stack does not match git-derived stack\n`,
-        '\nGraphite Stack:',
-        metaStack.toString(),
-        '\nGit Stack:',
-        gitStack.toString(),
-      ].join('\n')
-    );
+    throw new ValidationFailedError(metaStack, gitStack, currentBranch);
   }
 
   // Stacks are valid, we can update parentRevision
@@ -39,7 +31,7 @@ export function validate(scope: TScope, context: TContext): Branch[] {
     .map((b) => new Branch(b.name));
 }
 
-export function backfillParentShasOnValidatedStack(
+function backfillParentShasOnValidatedStack(
   stack: Stack,
   context: TContext
 ): void {
@@ -59,7 +51,7 @@ export function backfillParentShasOnValidatedStack(
     });
 }
 
-export function getStacksForValidation(
+function getStacksForValidation(
   currentBranch: Branch,
   scope: TScope,
   context: TContext

--- a/src/commands/downstack-commands/validate.ts
+++ b/src/commands/downstack-commands/validate.ts
@@ -12,7 +12,9 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async (context) => {
-    validate('DOWNSTACK', context);
-  });
+  return profile(
+    argv,
+    canonical,
+    async (context) => void validate('DOWNSTACK', context)
+  );
 };

--- a/src/commands/stack-commands/test.ts
+++ b/src/commands/stack-commands/test.ts
@@ -4,7 +4,6 @@ import tmp from 'tmp';
 import yargs from 'yargs';
 import { validate } from '../../actions/validate';
 import { TContext } from '../../lib/context';
-import { ValidationFailedError } from '../../lib/errors';
 import { checkoutBranch } from '../../lib/git/checkout_branch';
 import { currentBranchPrecondition } from '../../lib/preconditions';
 import { profile } from '../../lib/telemetry/profile';
@@ -52,7 +51,7 @@ function testStack(
   opts: { skipTrunk: boolean }
 ): void {
   const originalBranch = currentBranchPrecondition();
-  validateStack(context);
+  validate('FULLSTACK', context);
 
   context.splog.logInfo(chalk.grey(`Getting stack...`));
   const stack = new GitStackBuilder().fullStackFromBranch(
@@ -155,14 +154,4 @@ function logState(state: StateT, refresh: boolean, context: TContext) {
       }`
     );
   });
-}
-
-function validateStack(context: TContext): void {
-  try {
-    validate('FULLSTACK', context);
-  } catch (err) {
-    throw new ValidationFailedError(
-      `Failed to validate fullstack before testing`
-    );
-  }
 }

--- a/src/commands/stack-commands/validate.ts
+++ b/src/commands/stack-commands/validate.ts
@@ -12,7 +12,9 @@ export const description =
 export const builder = args;
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async (context) => {
-    validate('FULLSTACK', context);
-  });
+  return profile(
+    argv,
+    canonical,
+    async (context) => void validate('FULLSTACK', context)
+  );
 };

--- a/src/commands/upstack-commands/validate.ts
+++ b/src/commands/upstack-commands/validate.ts
@@ -12,7 +12,9 @@ export const builder = args;
 export const canonical = 'upstack validate';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return profile(argv, canonical, async (context) => {
-    validate('UPSTACK', context);
-  });
+  return profile(
+    argv,
+    canonical,
+    async (context) => void validate('UPSTACK', context)
+  );
 };

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { Branch } from '../wrapper-classes/branch';
+import { Stack } from '../wrapper-classes/stack';
 import {
   persistMergeConflictCallstack,
   TMergeConflictCallstack,
@@ -45,9 +46,21 @@ class RebaseConflictError extends ExitError {
 }
 
 class ValidationFailedError extends ExitError {
-  constructor(message: string) {
-    super(message);
+  branchesToFix: Branch[];
+  currentBranch: Branch;
+  constructor(metaStack: Stack, gitStack: Stack, currentBranch: Branch) {
+    super(
+      [
+        `Graphite stack does not match git-derived stack\n`,
+        '\nGraphite Stack:',
+        metaStack.toString(),
+        '\nGit Stack:',
+        gitStack.toString(),
+      ].join('\n')
+    );
     this.name = 'ValidationFailed';
+    this.branchesToFix = metaStack.source.children.map((c) => c.branch);
+    this.currentBranch = currentBranch;
   }
 }
 


### PR DESCRIPTION
I know storing the fix state in the validation exception is not a good pattern, but it seemed like cleanest way to reuse the validation code for now.  This will change upstack as we change how we do validation.