### PR TITLE
chore: fix changelog formatting

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -1,33 +1,33 @@
-# 0.18.6 2021-05-20
+## 0.18.6 2021-05-20
 
 - Fixed a bug where running `gt branch rename` on submitted branches would result in `gt` becoming largely unusable.
 - Added a new `--force/-f` option to `gt branch rename` that is required for already-submitted branches.
 - `gt branch rename` now respects character replacement settings.
 
-# 0.18.5 2021-05-19
+## 0.18.5 2021-05-19
 
 - `.` and `/` are no longer replaced in branch names.
 - Fixed a regression where the current branch wouldn't be selected by default in `gt branch checkout` interactive mode.
 - Upgraded `node` and `yarn` dependencies, please let us know if you see any weirdness!
 
-# 0.18.4 2021-05-16
+## 0.18.4 2021-05-16
 
 - `gt downstack sync` no longer requires turning on a configuration option to use (for real this time)
 
-# 0.18.3 2021-05-13
+## 0.18.3 2021-05-13
 
 - Rewrote `gt downstack sync` using a different mechanism for fetching remote stack dependencies.
 - `gt downstack sync` no longer requires turning on a configuration option to use.
 - Fixed an issue in `submit` where in-progress PR title wouldn't be saved if the user cancelled while writing the body.
 
-# 0.18.2 2021-05-12
+## 0.18.2 2021-05-12
 
 - Fixed certain cases of an issue where restacking after `stack edit` and `commit create` would use an incorrect upstream. A broader fix is coming in v0.19.0.
 - Fixed an issue where after certain `downstack edit` or `upstack onto` flows, branches would be pushed to GitHub in an order that caused them to be closed prematurely.
 - Added `gt branch-prefix --reset` to turn off the user prefix for automatically generated branch names.
 - Cleaned up copy in `submit` commands.
 
-# 0.18.1 2021-05-10
+## 0.18.1 2021-05-10
 
 - `gt repo sync` and `gt repo fix` now prompt to delete closed branches in addition to merged ones.
 - Added more customization for auto-generated branch name prefixes. Check out `gt user branch-date` and `gt user branch-replacement`.
@@ -38,7 +38,7 @@
 - Removed deprecation warning for `gt stacks` - it's been long enough.
 - Cleaned up interactive mode copy for `submit`.
 
-# 0.18.0 2021-05-04
+## 0.18.0 2021-05-04
 
 **New functionality**
 
@@ -86,11 +86,11 @@
 - Added infra to backfill the SHA of branch parent in metadata globally wherever it is safe to do so to prepare for an upcoming update to the stack validation algorithm that we expect to improve performance and reduce hangs.
 - Added plenty of tests and refactored code core to many commands for stability and future extensibility.
 
-# 0.17.11 2021-04-23
+## 0.17.11 2021-04-23
 
 - Fix an issue introduced in the previous version where the async calls to fill in PR info on `submit` would not be awaited serially, resulting in a poor user experience.
 
-# 0.17.10 2021-04-22
+## 0.17.10 2021-04-22
 
 - `sync` commands no longer allow pushing to branches associated with closed/merged PRs.
 - Rename `gt branch sync` to `gt branch pr-info` as its behavior is not aligned with the other `sync` commands.
@@ -100,7 +100,7 @@
 - Start tracking SHA of branch parent in metadata, a requirement for some upcoming features.
 - This version includes some initial changes to sync branch metadata with remote, gated by a hidden flag.
 
-# 0.17.9 2021-04-14
+## 0.17.9 2021-04-14
 
 - Flipped `gt log short` view to match other log commands and `up`/`down` naming convention. `↳` → `↱`!
 - Graphite now asks for confirmation if the user tries to submit an empty branch.
@@ -116,11 +116,11 @@
 - Fixed an issue where `gt repo max-branch-length` wouldn't print the configured value.
 - Added more debug information for the `--debug` option.
 
-# 0.17.8 2021-04-08
+## 0.17.8 2021-04-08
 
 - Happy Friday! This should fix many hangs that users are experiencing.
 
-# 0.17.7 2021-04-08
+## 0.17.7 2021-04-08
 
 - Graphite no longer cleans up local branches that share a name with merged branches on remote unless they have been associated with the merged PR (via a `submit` command).
 - Fix bug where PR info wasn't being synced periodically.
@@ -129,11 +129,11 @@
 - Fix a hang related to `git config diff.external` being set.
 - Fix autocompletions for `gt branch checkout`.
 
-# 0.17.6 2021-03-29
+## 0.17.6 2021-03-29
 
 - Support handling corrupted `.graphite_merge_conflict` files.
 
-# 0.17.5 2021-03-23
+## 0.17.5 2021-03-23
 
 - Add deprecation warnings for `gt branch next` and `gt branch prev` in favor of `gt branch up` and `gt branch down`, respectively.
 - Add `gt bu` and `gt bd` shortcuts for `gt branch up` and `gt branch down`, respectively.
@@ -143,48 +143,48 @@
 - Silence retype errors.
 - Minor copy updates.
 
-# 0.17.4 2021-02-25
+## 0.17.4 2021-02-25
 
 - Refactored config loading to reduce race conditions.
 - Add quotes around commit message in ammend command.
 - Minor copy updates.
 
-# 0.17.3 2021-02-25
+## 0.17.3 2021-02-25
 
 - Fix bug regarding repo config file reading from repo subdirs.
 
-# 0.17.2 2021-02-16
+## 0.17.2 2021-02-16
 
 - Support numbers when generating a branch name from a commit message through `gt bc -m <message>`
 - Prompt for a commit message when autogenerating an empty commit when running `branch create` with no staged changes.
 
-# 0.17.1 2021-02-15
+## 0.17.1 2021-02-15
 
 - Support creating new branches with no staged changes, by automatically creating an empty commit.
 
-# 0.17.0 2021-02-15
+## 0.17.0 2021-02-15
 
 - Enable changing existing PRs' draft status using the `--draft` flag on submit.
 - Add a new command, `gt downstack edit` which enables interactive reordering of stack branches.
 - Update implementation of `gt stack submit` to avoid GitHub rate limitted when submitting large stacks.
 
-# 0.16.8 2021-02-02
+## 0.16.8 2021-02-02
 
 - Enable manually setting reviewers on submit with the `-r` flag.
 
-# 0.16.7 2021-02-01
+## 0.16.7 2021-02-01
 
 - Allow Graphite to run when there are untracked files.
 
-# 0.16.6 2021-01-27
+## 0.16.6 2021-01-27
 
 - Fix issue with detecting downstack/upstack branches on submit
 
-# 0.16.5 2021-01-07
+## 0.16.5 2021-01-07
 
 - Fix issue with detecting some PR templates
 
-# 0.16.4 2021-12-13
+## 0.16.4 2021-12-13
 
 - Wildcard matching for ignored branches (`gt repo ignored-branches --set`) now accepts glob-patterns
 - Option to remove a branch from ignored list (`gt repo ignored-branches --unset`)
@@ -192,23 +192,23 @@
 - Bugfix: Submit to honor the --no-verify flag
 - Better logging and documentation to clarify behavior
 
-# 0.16.3 2021-12-3
+## 0.16.3 2021-12-3
 
 - Support up and down aliases for `gt branch` next/prev respectively.
 - Fix issue where `gt tips` could not be disabled.
 - Inherit shell editor preference for user from env ($GIT_EDITOR/$EDITOR) and prompt user to set shell editor preference on submit if env not set.
 - Allow user to change editor preference using `gt user editor`
 
-# 0.16.2 2021-10-25
+## 0.16.2 2021-10-25
 
 - Support for `gt continue` to continue the previous Graphite command when interrupted by a rebase.
 
-# 0.16.1 2021-10-14
+## 0.16.1 2021-10-14
 
 - Fix issue with `gt repo sync` deleting metadata for existing branches.
 - Reduce merge conflicts caused by `gt commit amend`.
 
-# 0.16.0 2021-10-12
+## 0.16.0 2021-10-12
 
 - Support for branch autocomplete functionality on gt branch-related commands. Enable this functionality by running `gt completion` and adding the ouputted bash script to your relevant bash profile (e.g. ~/.bashrc, ~/.zshrc).
 - Added functionality to query users for feedback on the Graphite CLI.
@@ -216,39 +216,39 @@
 - Submit also now includes a `--dry-run` flag to show the user what will be submitted in the invocation.
 - Submit queries GitHub for PRs before submitting, resolving an issue where submit would sometimes try to create a new PR though one already existed for that head branch/base branch combo on GitHub (Graphite just didn't know about it).
 
-# 0.15.1 2021-10-4
+## 0.15.1 2021-10-4
 
 - Fix `gt commit create -m` multi-word commit messages.
 
-# 0.15.0 2021-10-4
+## 0.15.0 2021-10-4
 
 - Support for `gt stack top` and `gt stack bottom`.
 - Adjusted logic for cleaning metadata in `gt repo sync`.
 
-# 0.14.4 2021-10-1
+## 0.14.4 2021-10-1
 
 - Improve performance of stack logic on repos with a high number of local branches.
 - Allow `gt commit create` to be used without `-m`, launching the system editor.
 - Infer the body of a PR from the commit message body (if it exists).
 - Add `gt repo trunk --set`.
 
-# 0.14.3 2021-09-30
+## 0.14.3 2021-09-30
 
 - Improved `gt repo sync` performance when repos have a high number of stale branches. `gt repo sync` now deletes branches more eagerly and has an optional flag to show progress (`--show-delete-progress`).
 - New command `gt repo fix` searches for common problems that cause degraded Graphite performance and suggests common remediations.
 
-# 0.14.2 2021-09-29
+## 0.14.2 2021-09-29
 
 - Tacit support for merge-based workflows; merges no longer cause exponential branching in `gt log` and hang `gt upstack onto`.
 - Fixes to recreation of debug state in `gt feedback debug-context --recreate`.
 
-# 0.14.1 2021-09-27
+## 0.14.1 2021-09-27
 
 - Assorted improvements to the `gt repo sync` merged branch deletion logic and options to fix dangling branches.
 - `gt branch parent --reset` resets Graphite's recorded parent for a branch (to undefined).
 - `gt branch sync --reset` resets Graphite's recorded PR info a branch (to undefined).
 
-# 0.14.0 2021-09-16
+## 0.14.0 2021-09-16
 
 - `gt debug-context` captures debug metadata from your repo and can send that to Screenplay to help troubleshoot issues.
 - `gt repo sync` now pulls in PR information for all local branches from GitHub to link any PRs Graphite doesn't know about/better remove already-merged branches.
@@ -256,12 +256,12 @@
 - Re-enable pull request base pushing from `repo sync`.
 - `gt branch create -m` now has `-a` flag to include staged changes in the commit.
 
-# 0.13.1 2021-09-01
+## 0.13.1 2021-09-01
 
 - Disable metadata deletion from "repo sync"
 - Disable pull request base pushing from "repo sync"
 
-# 0.13.0 2021-08-31
+## 0.13.0 2021-08-31
 
 - "stack submit" now checks if update is needed for each branch.
 - Support "upstack submit" and "branch submit"
@@ -277,7 +277,7 @@
 - Show PR and commit info in "log" command
 - Add tip advising against creating branches without commits.
 
-# 0.12.3 2021-08-23
+## 0.12.3 2021-08-23
 
 - Fix outdated copy reference to gp.
 - Print error stack trace when --debug flag is used.
@@ -286,15 +286,15 @@
 - Reduce unnecessary git ref calls to improve performance in large repos.
 - Support graceful handling of sigint.
 
-# 0.12.2 2021-08-23
+## 0.12.2 2021-08-23
 
 - Fix bug in `gt ls` stack traversal.
 
-# 0.12.1 2021-08-23
+## 0.12.1 2021-08-23
 
 - Fix bug resulting in always showing tips for `gt ls`.
 
-# 0.12.0 2021-08-23
+## 0.12.0 2021-08-23
 
 - Disallow branching off an ignored branch.
 - Disallow sibling branches on top of trunk branch.
@@ -302,7 +302,7 @@
 - Rewrite `gt ls` to improve speed and output formatting.
 - Optimize git ref traversal and memoization.
 
-# 0.11.0 2021-08-18
+## 0.11.0 2021-08-18
 
 - Support PR templates in "stack submit" command.
 - Update "stack submit" to support interactive title and description setting.
@@ -311,7 +311,7 @@
 - Fix a crash in logging that happened in a edge case involving trailing trunk branches.
 - Hide remote branches in "log long" output.
 
-# 0.10.0 2021-08-17
+## 0.10.0 2021-08-17
 
 - Fix case where commands fail if a branch's stack parent had been deleted.
 - Fix copy across CLI to use "gt" rather than the old "gp".
@@ -324,20 +324,20 @@
 - Throw actionable errors if two branches point at the same commit.
 - Add top level "graphite" alias such that the CLI can be called using both "gt" and "graphite".
 
-# 0.9.1 2021-08-15
+## 0.9.1 2021-08-15
 
 - Fix "gp" alias deprecation warning for homebrew installations.
 
-# 0.9.0 2021-08-15
+## 0.9.0 2021-08-15
 
 - Rename graphite CLI alias to "gt" from "gp" per feedback.
 
-# 0.8.2 2021-08-13
+## 0.8.2 2021-08-13
 
 - Improved performance of `gp stacks` command, particularly in repos with a large number of stale branches.
 - Changed search-space limiting settings to live at the top level and apply to both stacks and log. (`gp repo max-stacks-behind-trunk`, `gp repo max-days-behind-trunk`).
 
-# 0.8.1 2021-08-10
+## 0.8.1 2021-08-10
 
 - Improved performance of `gp log` command, particularly in repos with a large number of stale branches.
 - Users can now set the maximum number of stacks to show behind trunk in `gp log` (`gp repo log max-stacks-behind-trunk`) as well as the maximum age of stacks to show (`gp repo log max-days-behind-trunk`).

--- a/scripts/demo/abstract_demo.ts
+++ b/scripts/demo/abstract_demo.ts
@@ -1,14 +1,14 @@
-import cp from "child_process";
-import fs from "fs-extra";
-import path from "path";
-import tmp from "tmp";
+import cp from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
+import tmp from 'tmp';
 
 const OUTPUT_DIR = `${__dirname}/../../demo`;
 
-export default abstract class AbstractDemo {
+export abstract class AbstractDemo {
   name: string;
   commands: string[];
-  setup: (dir: string) => void;
+  setup: (_dir: string) => void;
 
   constructor(name: string, commands: string[], setup: (dir: string) => void) {
     this.name = name;
@@ -36,14 +36,14 @@ export default abstract class AbstractDemo {
         fs.removeSync(this.outputFilePath());
       }
       const recProcess = cp.spawn(
-        "/usr/local/bin/asciinema",
+        '/usr/local/bin/asciinema',
         [
-          "rec",
+          'rec',
           this.outputFilePath(),
-          "--stdin",
-          "--overwrite",
-          "--command",
-          "$SHELL",
+          '--stdin',
+          '--overwrite',
+          '--command',
+          '$SHELL',
         ],
         {
           detached: true,
@@ -51,7 +51,7 @@ export default abstract class AbstractDemo {
         }
       );
 
-      recProcess.on("close", (code) => {
+      recProcess.on('close', (code) => {
         if (code === 0) {
           resolve();
           return;
@@ -61,22 +61,23 @@ export default abstract class AbstractDemo {
         return;
       });
 
-      recProcess.on("error", (err) => {
-        console.error("Failed to start subprocess.");
+      recProcess.on('error', (err) => {
+        console.error('Failed to start subprocess.');
         console.error(err);
+        // eslint-disable-next-line no-restricted-syntax
         process.exit(1);
       });
 
       if (!recProcess) {
-        throw new Error("Failed to spawn process");
+        throw new Error('Failed to spawn process');
       }
 
       if (!recProcess.stdin) {
-        throw new Error("No stdin for subprocess");
+        throw new Error('No stdin for subprocess');
       }
 
-      recProcess.stdout.on("data", async function (data) {
-        if (data.toString().includes("$") || data.toString().includes("➜")) {
+      recProcess.stdout.on('data', async function (data) {
+        if (data.toString().includes('$') || data.toString().includes('➜')) {
           if (remainingCommands.length > 0) {
             writeCommand(recProcess, remainingCommands.pop()!);
           } else {
@@ -86,8 +87,8 @@ export default abstract class AbstractDemo {
         }
       });
 
-      recProcess.on("", (err) => {
-        console.error("Failed to start subprocess.");
+      recProcess.on('', (err) => {
+        console.error('Failed to start subprocess.');
         reject(err);
         return;
       });
@@ -96,7 +97,7 @@ export default abstract class AbstractDemo {
 
   public async create(): Promise<void> {
     const tmpDir = tmp.dirSync();
-    const demoDir = path.join(tmpDir.name, "demo");
+    const demoDir = path.join(tmpDir.name, 'demo');
     fs.mkdirSync(demoDir);
 
     console.log(`Setting up demo repo`);
@@ -128,9 +129,9 @@ export default abstract class AbstractDemo {
       .readFileSync(this.outputFilePath())
       .toString()
       .trim()
-      .split("\n");
+      .split('\n');
     lines.splice(1, 4);
-    fs.writeFileSync(this.outputFilePath(), lines.join("\n"));
+    fs.writeFileSync(this.outputFilePath(), lines.join('\n'));
   }
 }
 
@@ -139,10 +140,10 @@ function writeCommand(
   command: string
 ) {
   console.log(`Running command: ${command}`);
-  cp.execSync("sleep 3");
+  cp.execSync('sleep 3');
   for (const char of command) {
     process.stdin.write(char);
-    cp.execSync("sleep 0.01");
+    cp.execSync('sleep 0.01');
   }
-  process.stdin.write("\n");
+  process.stdin.write('\n');
 }

--- a/scripts/demo/full_demo.ts
+++ b/scripts/demo/full_demo.ts
@@ -1,7 +1,7 @@
 import { GitRepo } from '../../src/lib/utils/git_repo';
-import AbstractDemo from './abstract_demo';
+import { AbstractDemo } from './abstract_demo';
 
-export default class FullDemo extends AbstractDemo {
+export class FullDemo extends AbstractDemo {
   constructor() {
     super(
       'full',

--- a/scripts/demo/index.ts
+++ b/scripts/demo/index.ts
@@ -1,5 +1,5 @@
-import AbstractDemo from "./abstract_demo";
-import FullDemo from "./full_demo";
+import { AbstractDemo } from './abstract_demo';
+import { FullDemo } from './full_demo';
 
 const DEMOS: AbstractDemo[] = [new FullDemo()];
 


### PR DESCRIPTION
we used to do `##` looks like we stopped by accident at some point.  it formats better on github