### PR TITLE
Remove unnecessary /usr/bin/env

### DIFF
--- a/src/actions/submit/reviewers.ts
+++ b/src/actions/submit/reviewers.ts
@@ -12,7 +12,7 @@ export async function getReviewers(args: {
       type: 'list',
       name: 'reviewers',
       message: 'Reviewers (comma-separated GitHub usernames)',
-      seperator: ',',
+      separator: ',',
     },
     {
       onCancel: () => {

--- a/src/lib/utils/spawn.ts
+++ b/src/lib/utils/spawn.ts
@@ -2,7 +2,7 @@ import cp from 'child_process';
 
 // Spawns an async process that executes the specified file
 export function spawnDetached(filename: string, args: string[] = []): void {
-  cp.spawn('/usr/bin/env', ['node', filename, ...args], {
+  cp.spawn('node', [filename, ...args], {
     detached: true,
     stdio: 'ignore',
   }).unref();


### PR DESCRIPTION
**Context:**

https://graphite-community.slack.com/archives/C02DRNRA9RA/p1653624969970659
https://graphite-community.slack.com/archives/C02DRNRA9RA/p1645522107900559

**Changes In This Pull Request:**

Removes unnecessary dependency on `/usr/bin/env` and fixes a typo in the word `separator`.

**Test Plan:**
:

