### PR TITLE
feat: allow auth and user commands to be run outside of a repo

### DIFF
--- a/src/background_tasks/post_survey.ts
+++ b/src/background_tasks/post_survey.ts
@@ -3,13 +3,13 @@ import { request } from '@withgraphite/retyped-routes';
 import { API_SERVER } from '../lib/api/server';
 import { surveyConfigFactory } from '../lib/config/survey_config';
 import { userConfigFactory } from '../lib/config/user_config';
-import { TContext } from '../lib/context';
+import { TContextLite } from '../lib/context';
 import { spawnDetached } from '../lib/utils/spawn';
 
 // We try to post the survey response right after the user takes it, but in
 // case they quit early or there's some error, we'll continue to try to post
 // it in the future until it succeeds.
-export function postSurveyResponsesInBackground(context: TContext): void {
+export function postSurveyResponsesInBackground(context: TContextLite): void {
   // We don't worry about race conditions here - we can dedup on the server.
   if (context.surveyConfig.hasSurveyResponse()) {
     spawnDetached(__filename);

--- a/src/background_tasks/upgrade_prompt.ts
+++ b/src/background_tasks/upgrade_prompt.ts
@@ -6,12 +6,12 @@ import {
   messageConfigFactory,
   TMessageConfig,
 } from '../lib/config/message_config';
-import { TContext } from '../lib/context';
+import { TContextLite } from '../lib/context';
 import { getUserEmail } from '../lib/telemetry/context';
 import { SHOULD_REPORT_TELEMETRY } from '../lib/telemetry/post_traces';
 import { spawnDetached } from '../lib/utils/spawn';
 
-function printAndClearOldMessage(context: TContext): void {
+function printAndClearOldMessage(context: TContextLite): void {
   const oldMessage = context.messageConfig.data.message;
   // "Since we fetch the message asynchronously and display it when the user runs their next Graphite command,
   // double-check before showing the message if the CLI is still an old version
@@ -21,11 +21,7 @@ function printAndClearOldMessage(context: TContext): void {
     context.messageConfig.update((data) => (data.message = undefined));
   }
 }
-export function fetchUpgradePromptInBackground(context: TContext): void {
-  if (!context.repoConfig.graphiteInitialized()) {
-    return;
-  }
-
+export function fetchUpgradePromptInBackground(context: TContextLite): void {
   printAndClearOldMessage(context);
   spawnDetached(__filename);
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { graphite } from '../lib/runner';
+import { graphiteWithoutRepo } from '../lib/runner';
 
 const args = {
   token: {
@@ -19,7 +19,7 @@ export const builder = args;
 export const canonical = 'auth';
 
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv.token) {
       context.userConfig.update((data) => (data.authToken = argv.token));
       context.splog.info(

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -1,6 +1,6 @@
 import tmp from 'tmp';
 import yargs from 'yargs';
-import { graphite } from '../lib/runner';
+import { graphiteWithoutRepo } from '../lib/runner';
 import { gpExecSync } from '../lib/utils/exec_sync';
 import { GitRepo } from '../lib/utils/git_repo';
 import { makeId } from '../lib/utils/make_id';
@@ -14,7 +14,7 @@ export const builder = args;
 
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     const tmpDir = tmp.dirSync();
     context.splog.info(tmpDir.name);
     const repo = new GitRepo(tmpDir.name);

--- a/src/commands/dev-commands/cache.ts
+++ b/src/commands/dev-commands/cache.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { initContext } from '../../lib/context';
+import { initContext, initContextLite } from '../../lib/context';
 import { getCacheLock } from '../../lib/engine/cache_lock';
 
 export const command = 'cache';
@@ -19,7 +19,7 @@ type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 export const handler = async (argv: argsT): Promise<void> => {
   const cacheLock = getCacheLock();
   cacheLock.lock();
-  const context = initContext({ globalArguments: { debug: true } });
+  const context = initContext(initContextLite({ debug: true }));
   context.metaCache[argv.clear ? 'clear' : 'debug']();
   cacheLock.release();
 };

--- a/src/commands/repo-commands/repo_init.ts
+++ b/src/commands/repo-commands/repo_init.ts
@@ -19,8 +19,7 @@ export const canonical = 'repo init';
 export const description =
   'Create or regenerate a `.graphite_repo_config` file.';
 export const builder = args;
-export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+export const handler = async (argv: argsT): Promise<void> =>
+  graphite(argv, canonical, async (context) => {
     await init(context, argv.trunk);
   });
-};

--- a/src/commands/user-commands/branch_date.ts
+++ b/src/commands/user-commands/branch_date.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { graphite } from '../../lib/runner';
+import { graphiteWithoutRepo } from '../../lib/runner';
 import { getBranchDateEnabled } from '../../lib/utils/branch_name';
 
 const args = {
@@ -25,7 +25,7 @@ export const description =
   'Toggle prepending date to auto-generated branch names on branch creation.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv.enable) {
       context.userConfig.update((data) => (data.branchDate = true));
       context.splog.info(`Enabled date`);

--- a/src/commands/user-commands/branch_prefix.ts
+++ b/src/commands/user-commands/branch_prefix.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { graphite } from '../../lib/runner';
+import { graphiteWithoutRepo } from '../../lib/runner';
 import { setBranchPrefix } from '../../lib/utils/branch_name';
 
 const args = {
@@ -28,7 +28,7 @@ export const description =
   'The prefix which Graphite will prepend to generated branch names.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv.reset) {
       context.splog.info(`Reset branch-prefix`);
       setBranchPrefix('', context);

--- a/src/commands/user-commands/branch_replacement.ts
+++ b/src/commands/user-commands/branch_replacement.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { graphite } from '../../lib/runner';
+import { graphiteWithoutRepo } from '../../lib/runner';
 import { getBranchReplacement } from '../../lib/utils/branch_name';
 
 const args = {
@@ -32,7 +32,7 @@ export const description =
   'The character that will replace unsupported characters in generated branch names.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv['set-underscore']) {
       context.userConfig.update((data) => (data.branchReplacement = '_'));
       context.splog.info(`Set underscore (_) as the replacement character`);

--- a/src/commands/user-commands/editor.ts
+++ b/src/commands/user-commands/editor.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { graphite } from '../../lib/runner';
+import { graphiteWithoutRepo } from '../../lib/runner';
 
 const args = {
   set: {
@@ -23,7 +23,7 @@ export const description = 'The editor opened by Graphite';
 export const canonical = 'user editor';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv.set) {
       context.userConfig.update((data) => (data.editor = argv.set));
       context.splog.info(`Editor set to ${chalk.cyan(argv.set)}`);

--- a/src/commands/user-commands/tips.ts
+++ b/src/commands/user-commands/tips.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { graphite } from '../../lib/runner';
+import { graphiteWithoutRepo } from '../../lib/runner';
 
 const args = {
   enable: {
@@ -23,7 +23,7 @@ export const description = 'Show tips while using Graphite';
 export const canonical = 'user tips';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> => {
-  return graphite(argv, canonical, async (context) => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
     if (argv.enable) {
       context.userConfig.update((data) => (data.tips = true));
       context.splog.info(`tips enabled`);

--- a/src/lib/config/compose_config.ts
+++ b/src/lib/config/compose_config.ts
@@ -100,11 +100,12 @@ function configAbsolutePaths(
   defaultLocations: TDefaultConfigLocation[],
   defaultPathOverride?: string
 ): string[] {
-  const repoRoot = getRepoRootPathPrecondition();
-  const home = os.homedir();
   return (defaultPathOverride ? [defaultPathOverride] : []).concat(
     defaultLocations.map((l) =>
-      path.join(l.relativeTo === 'REPO' ? repoRoot : home, l.relativePath)
+      path.join(
+        l.relativeTo === 'REPO' ? getRepoRootPathPrecondition() : os.homedir(),
+        l.relativePath
+      )
     )
   );
 }

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -8,7 +8,12 @@ import { init } from '../actions/init';
 import { refreshPRInfoInBackground } from '../background_tasks/fetch_pr_info';
 import { postSurveyResponsesInBackground } from '../background_tasks/post_survey';
 import { fetchUpgradePromptInBackground } from '../background_tasks/upgrade_prompt';
-import { initContext, TContext } from './context';
+import {
+  initContext,
+  initContextLite,
+  TContext,
+  TContextLite,
+} from './context';
 import { getCacheLock, TCacheLock } from './engine/cache_lock';
 import {
   BadTrunkOperationError,
@@ -32,16 +37,39 @@ export async function graphite(
   canonicalName: string,
   handler: (context: TContext) => Promise<void>
 ): Promise<void> {
+  return graphiteInternal(args, canonicalName, {
+    repo: true as const,
+    run: handler,
+  });
+}
+
+export async function graphiteWithoutRepo(
+  args: yargs.Arguments & TGlobalArguments,
+  canonicalName: string,
+  handler: (context: TContextLite) => Promise<void>
+): Promise<void> {
+  return graphiteInternal(args, canonicalName, {
+    repo: false as const,
+    run: handler,
+  });
+}
+
+async function graphiteInternal(
+  args: yargs.Arguments & TGlobalArguments,
+  canonicalName: string,
+  handler: TGraphiteCommandHandler
+): Promise<void> {
   const parsedArgs = parseArgs(args);
 
   const start = Date.now();
-  const cacheLock = getCacheLock();
+  const handlerWithCacheLock: TGraphiteCommandHandlerWithCacheLock =
+    handler.repo ? { ...handler, cacheLock: getCacheLock() } : handler;
 
   registerSigintHandler({
     commandName: parsedArgs.command,
     canonicalCommandName: canonicalName,
     startTime: start,
-    cacheLock,
+    cacheLock: handlerWithCacheLock.cacheLock,
   });
 
   const err = await tracer.span(
@@ -55,7 +83,15 @@ export async function graphite(
         alias: parsedArgs.alias,
       },
     },
-    () => graphiteHelper(args, cacheLock, canonicalName, handler)
+    () => {
+      const contextLite = initContextLite(args);
+      return graphiteHelper(
+        canonicalName,
+        args,
+        contextLite,
+        handlerWithCacheLock
+      );
+    }
   );
   const end = Date.now();
   postTelemetryInBackground({
@@ -70,20 +106,24 @@ export async function graphite(
 // Then we can simplify this function and signature a lot
 // eslint-disable-next-line max-params
 async function graphiteHelper(
-  args: yargs.Arguments & TGlobalArguments,
-  cacheLock: TCacheLock,
   canonicalName: string,
-  handler: (context: TContext) => Promise<void>
+  args: TGlobalArguments,
+  contextLite: TContextLite,
+  handler: TGraphiteCommandHandlerWithCacheLock
 ): Promise<Error | undefined> {
-  const context = initContext({
-    globalArguments: args,
-  });
+  const context = handler.repo
+    ? { ...handler, ...initContext(contextLite, args) }
+    : { ...handler, ...contextLite };
 
   const err = await (async (): Promise<Error | undefined> => {
     try {
-      cacheLock.lock();
       fetchUpgradePromptInBackground(context);
       postSurveyResponsesInBackground(context);
+      if (!context.repo) {
+        await context.run(context);
+        return undefined;
+      }
+
       refreshPRInfoInBackground(context);
 
       if (
@@ -97,7 +137,7 @@ async function graphiteHelper(
         await init(context);
       }
 
-      await handler(context);
+      await context.run(context);
       return undefined;
     } catch (err) {
       handleGraphiteError(err, context);
@@ -112,6 +152,10 @@ async function graphiteHelper(
     }
   })();
 
+  if (!context.repo) {
+    return err;
+  }
+
   try {
     context.metaCache.persist();
   } catch (persistError) {
@@ -119,12 +163,12 @@ async function graphiteHelper(
     context.splog.debug(`Failed to persist Graphite cache`);
   }
 
-  cacheLock.release();
+  context.cacheLock.release();
   return err;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function handleGraphiteError(err: any, context: TContext): void {
+function handleGraphiteError(err: any, context: TContextLite): void {
   switch (err.constructor) {
     case KilledError:
       // pass
@@ -170,3 +214,22 @@ function handleGraphiteError(err: any, context: TContext): void {
       return;
   }
 }
+
+// typescript is fun!
+type TGraphiteCommandHandler =
+  | { repo: true; run: (context: TContext) => Promise<void> }
+  | {
+      repo: false;
+      run: (contextLite: TContextLite) => Promise<void>;
+    };
+type TGraphiteCommandHandlerWithCacheLock =
+  | {
+      repo: true;
+      run: (context: TContext) => Promise<void>;
+      cacheLock: TCacheLock;
+    }
+  | {
+      repo: false;
+      run: (contextLite: TContextLite) => Promise<void>;
+      cacheLock?: undefined;
+    };

--- a/src/lib/telemetry/sigint_handler.ts
+++ b/src/lib/telemetry/sigint_handler.ts
@@ -7,10 +7,10 @@ export function registerSigintHandler(opts: {
   commandName: string;
   canonicalCommandName: string;
   startTime: number;
-  cacheLock: TCacheLock;
+  cacheLock: TCacheLock | undefined;
 }): void {
   process.on('SIGINT', (): never => {
-    opts.cacheLock.release();
+    opts.cacheLock?.release();
     const err = new KilledError();
     // End all current traces abruptly.
     tracer.allSpans.forEach((s) => s.end(err));

--- a/src/lib/utils/branch_name.ts
+++ b/src/lib/utils/branch_name.ts
@@ -1,4 +1,4 @@
-import { TContext } from '../context';
+import { TContext, TContextLite } from '../context';
 
 // 255 minus 21 (for 'refs/branch-metadata/')
 const MAX_BRANCH_NAME_BYTE_LENGTH = 234;
@@ -6,7 +6,7 @@ const BRANCH_NAME_REPLACE_REGEX = /[^-_/.a-zA-Z0-9]+/g;
 
 export function replaceUnsupportedCharacters(
   input: string,
-  context: TContext
+  context: TContextLite
 ): string {
   return input.replace(
     BRANCH_NAME_REPLACE_REGEX,
@@ -14,7 +14,7 @@ export function replaceUnsupportedCharacters(
   );
 }
 
-export function getBranchReplacement(context: TContext): string {
+export function getBranchReplacement(context: TContextLite): string {
   return context.userConfig.data.branchReplacement ?? '_';
 }
 
@@ -51,12 +51,15 @@ export function newBranchName(
   );
 }
 
-export function setBranchPrefix(newPrefix: string, context: TContext): string {
+export function setBranchPrefix(
+  newPrefix: string,
+  context: TContextLite
+): string {
   const prefix = replaceUnsupportedCharacters(newPrefix, context);
   context.userConfig.update((data) => (data.branchPrefix = prefix));
   return prefix;
 }
 
-export function getBranchDateEnabled(context: TContext): boolean {
+export function getBranchDateEnabled(context: TContextLite): boolean {
   return context.userConfig.data.branchDate ?? true;
 }

--- a/test/lib/scenes/abstract_scene.ts
+++ b/test/lib/scenes/abstract_scene.ts
@@ -1,6 +1,10 @@
 import fs from 'fs-extra';
 import tmp from 'tmp';
-import { initContext, TContext } from '../../../src/lib/context';
+import {
+  initContext,
+  initContextLite,
+  TContext,
+} from '../../../src/lib/context';
 import { cuteString } from '../../../src/lib/utils/cute_string';
 import { GitRepo } from '../../../src/lib/utils/git_repo';
 
@@ -45,14 +49,16 @@ export abstract class AbstractScene {
   public getContext(): TContext {
     const oldDir = process.cwd();
     process.chdir(this.tmpDir.name);
-    const context = initContext({
-      globalArguments: {
+    const context = initContext(
+      initContextLite({
         interactive: false,
         quiet: !!process.env.DEBUG,
         debug: !!process.env.DEBUG,
+      }),
+      {
         verify: false,
-      },
-    });
+      }
+    );
     process.chdir(oldDir);
     return context;
   }


### PR DESCRIPTION
Adds a contextLite that we use instead of context when we don't need repo info.  should also make those commands faster.  learning that typescript is pretty good at letting you keep refactors small across the rest of the codebase as long as you have one place that you're ok with hiding the poop