### PR TITLE
fix: escape literally everything

### DIFF
--- a/src/actions/edit/edit_downstack.ts
+++ b/src/actions/edit/edit_downstack.ts
@@ -1,6 +1,7 @@
 import { TContext } from '../../lib/context';
 import { SCOPE } from '../../lib/engine/scope_spec';
 import { ExitFailedError } from '../../lib/errors';
+import { q } from '../../lib/utils/escape_for_shell';
 import { gpExecSync } from '../../lib/utils/exec_sync';
 import { performInTmpDir } from '../../lib/utils/perform_in_tmp_dir';
 import { restackBranches } from '../restack';
@@ -49,7 +50,7 @@ async function promptForEdit(context: TContext): Promise<string[]> {
     const editFilePath = createStackEditFile({ branchNames, tmpDir }, context);
     gpExecSync(
       {
-        command: `${context.userConfig.getEditor()} "${editFilePath}"`,
+        command: `${context.userConfig.getEditor()} ${q(editFilePath)}`,
         options: { stdio: 'inherit' },
       },
       (err) => {

--- a/src/actions/test.ts
+++ b/src/actions/test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import tmp from 'tmp';
 import { TContext } from '../lib/context';
 import { SCOPE, TScopeSpec } from '../lib/engine/scope_spec';
+import { q } from '../lib/utils/escape_for_shell';
 import { gpExecSync } from '../lib/utils/exec_sync';
 
 type TTestStatus = '[pending]' | '[success]' | '[fail]' | '[running]';
@@ -65,7 +66,7 @@ function testBranch(
   // Execute the command.
   fs.appendFileSync(opts.outputPath, `\n\n${opts.branchName}\n`);
   const startTime = Date.now();
-  const output = gpExecSync({ command: `${opts.command} 2>&1` }, () => {
+  const output = gpExecSync({ command: `${q(opts.command)} 2>&1` }, () => {
     opts.state[opts.branchName].status = '[fail]';
   });
   opts.state[opts.branchName].duration = Date.now() - startTime;

--- a/src/lib/config/repo_config.ts
+++ b/src/lib/config/repo_config.ts
@@ -1,5 +1,6 @@
 import * as t from '@withgraphite/retype';
 import { ExitFailedError } from '../errors';
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 import { composeConfig } from './compose_config';
 
@@ -78,7 +79,7 @@ function inferRepoGitHubInfo(remote: string): {
   // If a user runs into this is not true, they can manually edit the repo config
   // file to overrule what our CLI tries to intelligently infer.
   const url = gpExecSync({
-    command: `git config --get remote.${remote}.url`,
+    command: `git config --get remote.${q(remote)}.url`,
   });
 
   const inferError = new ExitFailedError(

--- a/src/lib/debug_context.ts
+++ b/src/lib/debug_context.ts
@@ -17,6 +17,7 @@ import { getShaOrThrow } from './git/get_sha';
 import { getBranchNamesAndRevisions } from './git/sorted_branch_names';
 import { switchBranch } from './git/switch_branch';
 import { cuteString } from './utils/cute_string';
+import { q } from './utils/escape_for_shell';
 import { gpExecSync } from './utils/exec_sync';
 import { TSplog } from './utils/splog';
 
@@ -116,7 +117,9 @@ function createBranches(
   Object.keys(opts.branches).forEach((branch) => {
     const originalRef = opts.refMappingsOldToNew[opts.branches[branch]];
     if (branch != gpExecSync({ command: `git branch --show-current` })) {
-      gpExecSync({ command: `git branch -f ${branch} ${originalRef}` });
+      gpExecSync({
+        command: `git branch -f ${q(branch)} ${originalRef}`,
+      });
     } else {
       splog.warn(
         `Skipping creating ${branch} which matches the name of the current branch`

--- a/src/lib/engine/cache.ts
+++ b/src/lib/engine/cache.ts
@@ -469,7 +469,6 @@ export function composeMetaCache({
       const parentCachedMeta = cache.branches[parentBranchName];
       assertCachedMetaIsValidOrTrunk(parentCachedMeta);
       switchBranch(branchName, { new: true });
-
       updateMeta(branchName, {
         validationResult: 'VALID',
         parentBranchName,

--- a/src/lib/engine/metadata_ref.ts
+++ b/src/lib/engine/metadata_ref.ts
@@ -1,4 +1,5 @@
 import { cuteString } from '../utils/cute_string';
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync, gpExecSyncAndSplitLines } from '../utils/exec_sync';
 
 type TBranchPRState = 'OPEN' | 'CLOSED' | 'MERGED';
@@ -37,7 +38,7 @@ export function writeMetadataRef(
   gpExecSync({
     command: `git ${
       opts ? `-C "${opts.dir}"` : ''
-    } update-ref refs/branch-metadata/${branchName} ${metaSha}`,
+    } update-ref refs/branch-metadata/${q(branchName)} ${metaSha}`,
     options: {
       stdio: 'ignore',
     },
@@ -54,7 +55,7 @@ export function readMetadataRef(
       gpExecSync({
         command: `git ${
           opts ? `-C "${opts.dir}" ` : ''
-        }cat-file -p refs/branch-metadata/${branchName} 2> /dev/null`,
+        }cat-file -p refs/branch-metadata/${q(branchName)} 2> /dev/null`,
       })
     );
   } catch {
@@ -64,7 +65,7 @@ export function readMetadataRef(
 
 export function deleteMetadataRef(branchName: string): void {
   gpExecSync({
-    command: `git update-ref -d refs/branch-metadata/${branchName}`,
+    command: `git update-ref -d refs/branch-metadata/${q(branchName)}`,
   });
 }
 

--- a/src/lib/git/branch_move.ts
+++ b/src/lib/git/branch_move.ts
@@ -1,8 +1,9 @@
 import { ExitFailedError } from '../errors';
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function branchMove(newName: string): void {
-  gpExecSync({ command: `git branch -m ${newName}` }, (err) => {
+  gpExecSync({ command: `git branch -m ${q(newName)}` }, (err) => {
     throw new ExitFailedError(`Failed to rename the current branch.`, err);
   });
 }

--- a/src/lib/git/commit_range.ts
+++ b/src/lib/git/commit_range.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSyncAndSplitLines } from '../utils/exec_sync';
 
 const FORMAT = { SHA: '%H', READABLE: '%h - %s' } as const;
@@ -9,6 +10,8 @@ export function getCommitRange(
   format: TCommitFormat
 ): string[] {
   return gpExecSyncAndSplitLines({
-    command: `git --no-pager log --pretty=format:"${FORMAT[format]}" ${base}..${head}`,
+    command: `git --no-pager log --pretty=format:"${FORMAT[format]}" ${q(
+      base
+    )}..${q(head)}`,
   });
 }

--- a/src/lib/git/commit_tree.ts
+++ b/src/lib/git/commit_tree.ts
@@ -1,7 +1,8 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSyncAndSplitLines } from '../utils/exec_sync';
 
 export function getCommitTree(branchNames: string[]): Record<string, string[]> {
-  const allBranches = branchNames.join(' ');
+  const allBranches = q(branchNames.join(' '));
   const ret: Record<string, string[]> = {};
   gpExecSyncAndSplitLines({
     command:

--- a/src/lib/git/delete_branch.ts
+++ b/src/lib/git/delete_branch.ts
@@ -1,7 +1,8 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function deleteBranch(branchName: string): void {
   gpExecSync({
-    command: `git branch -qD ${branchName}`,
+    command: `git branch -qD ${q(branchName)}`,
   });
 }

--- a/src/lib/git/detect_unsubmitted_changes.ts
+++ b/src/lib/git/detect_unsubmitted_changes.ts
@@ -1,11 +1,14 @@
 import { ExitFailedError } from '../errors';
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function detectUnsubmittedChanges(branchName: string): boolean {
   return (
     gpExecSync(
       {
-        command: `git --no-pager log ${branchName} --not --remotes --simplify-by-decoration --decorate --oneline --`,
+        command: `git --no-pager log ${q(
+          branchName
+        )} --not --remotes --simplify-by-decoration --decorate --oneline --`,
       },
       () => {
         throw new ExitFailedError(

--- a/src/lib/git/diff.ts
+++ b/src/lib/git/diff.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function detectStagedChanges(): boolean {
@@ -11,7 +12,9 @@ export function detectStagedChanges(): boolean {
 export function isDiffEmpty(left: string, right: string): boolean {
   return (
     gpExecSync({
-      command: `git --no-pager diff --no-ext-diff --shortstat ${left} ${right} -- `,
+      command: `git --no-pager diff --no-ext-diff --shortstat ${q(left)} ${q(
+        right
+      )} -- `,
     }).length === 0
   );
 }

--- a/src/lib/git/fetch_branch.ts
+++ b/src/lib/git/fetch_branch.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 import { getShaOrThrow } from './get_sha';
 
@@ -6,7 +7,9 @@ const FETCH_BASE = 'refs/gt-metadata/FETCH_BASE';
 export function fetchBranch(remote: string, branchName: string): void {
   gpExecSync(
     {
-      command: `git fetch --no-write-fetch-head -q  ${remote} +${branchName}:${FETCH_HEAD}`,
+      command: `git fetch --no-write-fetch-head -q  ${q(branchName)} +${q(
+        branchName
+      )}:${FETCH_HEAD}`,
     },
     (err) => {
       throw err;
@@ -22,7 +25,7 @@ export function readFetchBase(): string {
 }
 
 export function writeFetchBase(sha: string): void {
-  gpExecSync({ command: `git update-ref ${FETCH_BASE} ${sha}` }, (err) => {
+  gpExecSync({ command: `git update-ref ${FETCH_BASE} ${q(sha)}` }, (err) => {
     throw err;
   });
 }

--- a/src/lib/git/find_remote_branch.ts
+++ b/src/lib/git/find_remote_branch.ts
@@ -1,10 +1,11 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSyncAndSplitLines } from '../utils/exec_sync';
 
 export function findRemoteBranch(remote: string): string | undefined {
   // e.g. for most repos: branch.main.remote origin
   // we take the first line of the output
   const branchName = gpExecSyncAndSplitLines({
-    command: `git config --get-regexp remote$ "^${remote}$"`,
+    command: `git config --get-regexp remote$ "^${q(remote)}$"`,
   })[0]
     // and retrieve branchName from `branch.<branchName>.remote`
     ?.split('.')[1];

--- a/src/lib/git/get_sha.ts
+++ b/src/lib/git/get_sha.ts
@@ -1,20 +1,27 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function getShaOrThrow(ref: string): string {
-  return gpExecSync({ command: `git rev-parse ${ref} 2>/dev/null` }, (err) => {
-    throw err;
-  });
+  return gpExecSync(
+    { command: `git rev-parse ${q(ref)} 2>/dev/null` },
+    (err) => {
+      throw err;
+    }
+  );
 }
 
 export function getSha(ref: string): string | undefined {
   return (
-    gpExecSync({ command: `git rev-parse ${ref} 2>/dev/null` }) || undefined
+    gpExecSync({
+      command: `git rev-parse ${q(ref)} 2>/dev/null`,
+    }) || undefined
   );
 }
 
 export function getRemoteSha(ref: string, remote: string): string | undefined {
   return (
-    gpExecSync({ command: `git ls-remote ${remote} ${ref} | cut -f1 -w` }) ||
-    undefined
+    gpExecSync({
+      command: `git ls-remote ${q(remote)} ${q(ref)} | cut -f1 -w`,
+    }) || undefined
   );
 }

--- a/src/lib/git/is_merged.ts
+++ b/src/lib/git/is_merged.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 import { isDiffEmpty } from './diff';
 
@@ -11,7 +12,11 @@ export function isMerged({
   // Are the changes on this branch already applied to main?
   if (
     gpExecSync({
-      command: `git cherry ${trunkName} $(git commit-tree $(git rev-parse "${branchName}^{tree}") -p $(git merge-base ${branchName} ${trunkName}) -m _)`,
+      command: `git cherry ${q(
+        trunkName
+      )} $(git commit-tree $(git rev-parse ${q(
+        branchName
+      )}^{tree}) -p $(git merge-base ${q(branchName)} ${q(trunkName)}) -m _)`,
     }).startsWith('-')
   ) {
     return true;

--- a/src/lib/git/merge_base.ts
+++ b/src/lib/git/merge_base.ts
@@ -1,5 +1,8 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function getMergeBase(left: string, right: string): string {
-  return gpExecSync({ command: `git merge-base ${left} ${right}` });
+  return gpExecSync({
+    command: `git merge-base ${q(left)} ${q(right)}`,
+  });
 }

--- a/src/lib/git/prune_remote.ts
+++ b/src/lib/git/prune_remote.ts
@@ -1,5 +1,6 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function pruneRemote(remote: string): void {
-  gpExecSync({ command: `git remote prune ${remote}` });
+  gpExecSync({ command: `git remote prune ${q(remote)}` });
 }

--- a/src/lib/git/pull_branch.ts
+++ b/src/lib/git/pull_branch.ts
@@ -1,8 +1,11 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function pullBranch(remote: string, branchName: string): void {
   gpExecSync(
-    { command: `git pull -q --ff-only ${remote} ${branchName}` },
+    {
+      command: `git pull -q --ff-only ${q(remote)} ${q(branchName)}`,
+    },
     (err) => {
       throw err;
     }

--- a/src/lib/git/push_branch.ts
+++ b/src/lib/git/push_branch.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function pushBranch(opts: {
@@ -8,8 +9,8 @@ export function pushBranch(opts: {
   gpExecSync(
     {
       command: [
-        `git push ${opts.remote}`,
-        `--force-with-lease ${opts.branchName} 2>&1`,
+        `git push ${q(opts.remote)}`,
+        `--force-with-lease ${q(opts.branchName)} 2>&1`,
         ...[opts.noVerify ? ['--no-verify'] : []],
       ].join(' '),
     },

--- a/src/lib/git/rebase.ts
+++ b/src/lib/git/rebase.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 import { rebaseInProgress } from './rebase_in_progress';
 
@@ -8,7 +9,9 @@ export function restack(args: {
   branchName: string;
 }): TRebaseResult {
   gpExecSync({
-    command: `git rebase --onto ${args.parentBranchName} ${args.parentBranchRevision} ${args.branchName}`,
+    command: `git rebase --onto ${q(args.parentBranchName)} ${q(
+      args.parentBranchRevision
+    )} ${q(args.branchName)}`,
     options: { stdio: 'ignore' },
   });
   return rebaseInProgress() ? 'REBASE_CONFLICT' : 'REBASE_DONE';
@@ -27,7 +30,9 @@ export function rebaseInteractive(args: {
   branchName: string;
 }): TRebaseResult {
   gpExecSync({
-    command: `git rebase -i ${args.parentBranchRevision}`,
+    command: `git rebase -i ${q(args.parentBranchRevision)} ${q(
+      args.branchName
+    )}`,
     options: { stdio: 'inherit' },
   });
   return rebaseInProgress() ? 'REBASE_CONFLICT' : 'REBASE_DONE';

--- a/src/lib/git/set_remote_tracking.ts
+++ b/src/lib/git/set_remote_tracking.ts
@@ -1,3 +1,4 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function setRemoteTracking({
@@ -10,7 +11,11 @@ export function setRemoteTracking({
   sha: string;
 }): void {
   gpExecSync(
-    { command: `git update-ref refs/remotes/${remote}/${branchName} ${sha}` },
+    {
+      command: `git update-ref refs/remotes/${q(remote)}/${q(branchName)} ${q(
+        sha
+      )}`,
+    },
     (err) => {
       throw err;
     }

--- a/src/lib/git/show_commits.ts
+++ b/src/lib/git/show_commits.ts
@@ -1,8 +1,11 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function showCommits(base: string, head: string, patch?: boolean): void {
   gpExecSync({
-    command: `git --no-pager log ${patch ? '-p' : ''} ${base}..${head} --`,
+    command: `git --no-pager log ${patch ? '-p' : ''} ${q(base)}..${q(
+      head
+    )} --`,
     options: { stdio: 'inherit' },
   });
 }

--- a/src/lib/git/switch_branch.ts
+++ b/src/lib/git/switch_branch.ts
@@ -1,11 +1,12 @@
 import chalk from 'chalk';
 import { ExitFailedError } from '../errors';
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function switchBranch(branch: string, opts?: { new?: boolean }): void {
   gpExecSync(
     {
-      command: `git switch ${opts?.new ? '-c' : ''}"${branch}"`,
+      command: `git switch ${opts?.new ? '-c ' : ''}${q(branch)}`,
       options: { stdio: 'ignore' },
     },
     () => {

--- a/src/lib/git/write_branch.ts
+++ b/src/lib/git/write_branch.ts
@@ -1,7 +1,8 @@
+import { q } from '../utils/escape_for_shell';
 import { gpExecSync } from '../utils/exec_sync';
 
 export function forceCreateBranch(branchName: string, sha: string): void {
   gpExecSync({
-    command: `git switch -C ${branchName} ${sha}`,
+    command: `git switch -C ${q(branchName)} ${q(sha)}`,
   });
 }

--- a/src/lib/utils/escape_for_shell.ts
+++ b/src/lib/utils/escape_for_shell.ts
@@ -1,0 +1,9 @@
+const SINGLE_QUOTE = "'";
+const BACKSLASH = '\\';
+
+export function q(source: string): string {
+  return `${SINGLE_QUOTE}${source.replaceAll(
+    SINGLE_QUOTE,
+    `${SINGLE_QUOTE}${BACKSLASH}${SINGLE_QUOTE}${SINGLE_QUOTE}`
+  )}${SINGLE_QUOTE}`;
+}

--- a/test/fast/graphite_utils/escape_for_shell.test.ts
+++ b/test/fast/graphite_utils/escape_for_shell.test.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { execSync } from 'child_process';
+import { q } from '../../../src/lib/utils/escape_for_shell';
+
+describe('shell escaping', function () {
+  for (const s of [
+    'HELLO',
+    'Hello, world!',
+    "'''\"\"\"'''",
+    '\\/|$*&(*&^#$',
+    [...Array(256).keys()]
+      .slice(32)
+      .map((n) => String.fromCharCode(n))
+      .join(''),
+  ]) {
+    it('outputs its input when passed through echo', async () => {
+      expect(execSync(`echo ${q(s)}`, { encoding: 'utf-8' })).to.equal(
+        `${s}\n`
+      );
+    });
+  }
+});


### PR DESCRIPTION
q is for quote, singlechar function name seems fine to me given we're only calling it in execsync and its clear from the import what it does