### PR TITLE
feat(track): support targeting current branch

### DIFF
--- a/src/commands/branch-commands/track.ts
+++ b/src/commands/branch-commands/track.ts
@@ -8,13 +8,13 @@ import { graphite } from '../../lib/runner';
 
 const args = {
   branch: {
-    describe: `Branch to begin tracking.`,
+    describe: `Branch to begin tracking. Defaults to the current branch.`,
     demandOption: false,
     positional: true,
     type: 'string',
   },
   parent: {
-    describe: `The tracked branch's parent. Defaults to the current branch.`,
+    describe: `The tracked branch's parent. Defaults to trunk if targeting the current branch. Defaults to the current branch if targeting any other branch.`,
     demandOption: false,
     positional: false,
     type: 'string',
@@ -36,8 +36,7 @@ export const command = 'track [branch]';
 export const canonical = 'branch track';
 export const aliases = ['tr'];
 export const description = [
-  'Start tracking a branch with Graphite by setting its parent to (by default) the current branch.',
-  'When used without arguments, tracks the current branch by setting its parent to trunk.',
+  'Start tracking the current branch (by default) with Graphite by setting its parent to trunk (by default).',
   'This command can also be used to fix corrupted Graphite metadata.',
 ].join(' ');
 export const builder = args;

--- a/src/commands/branch-commands/track.ts
+++ b/src/commands/branch-commands/track.ts
@@ -37,6 +37,7 @@ export const canonical = 'branch track';
 export const aliases = ['tr'];
 export const description = [
   'Start tracking a branch with Graphite by setting its parent to (by default) the current branch.',
+  'When used without arguments, tracks the current branch by setting its parent to trunk.',
   'This command can also be used to fix corrupted Graphite metadata.',
 ].join(' ');
 export const builder = args;

--- a/test/fast/commands/branch/track.test.ts
+++ b/test/fast/commands/branch/track.test.ts
@@ -33,5 +33,33 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand('branch down');
       expect(scene.repo.currentBranchName()).to.eq('main');
     });
+
+    it('Can track and restack the current branch if previously untracked', () => {
+      // Create our dangling branch
+      scene.repo.createAndCheckoutBranch('a');
+      scene.repo.createChangeAndCommit('a1', 'a1');
+      scene.repo.createChangeAndCommit('a2', 'a2');
+      scene.repo.createChangeAndCommit('a3', 'a3');
+
+      // Move main forward
+      scene.repo.checkoutBranch('main');
+      scene.repo.createChangeAndCommit('b', 'b');
+
+      // we should be able to track the dangling branch 'a' while it's checked out
+      scene.repo.checkoutBranch('a');
+      expect(() => {
+        scene.repo.execCliCommand('branch track');
+      }).to.not.throw();
+
+      expectCommits(scene.repo, 'a3, a2, a1, 1');
+
+      scene.repo.execCliCommand('branch restack');
+
+      expectCommits(scene.repo, 'a3, a2, a1, b, 1');
+
+      // Prove that we have meta now.
+      scene.repo.execCliCommand('branch down');
+      expect(scene.repo.currentBranchName()).to.eq('main');
+    });
   });
 }


### PR DESCRIPTION
**Context:**

For users with existing workflows that create branches it is very handy
to quickly be able to start tracking the current branch after the fact.


**Changes In This Pull Request:**

- Make the test pass by updating the argument parsing logic according to
  the above feature description.

**Test Plan:**

- Add test that verifies that the `gt branch track` command can be run
  on an untracked branched without arguments, and that it then tracks
  the current branch.

**Concerns / side-effects of the changes**

- This assumes that the feature above is purely a UX change, and not
  something that the underlying system needs to know or care about.

