### PR TITLE
(probably should not be merged) chore(docker): add reproducibility through docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18
+
+WORKDIR /usr/src/app/
+
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y git
+
+RUN git config --global user.email "theuser@example.com"
+RUN git config --global user.name "theuser"
+
+COPY package.json .
+COPY yarn.lock .
+
+RUN yarn global add typescript@latest
+RUN yarn install
+
+COPY . .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  test:
+    build: .
+    # environment:
+    #   - DEBUG=1
+    command:
+      ["yarn", "run", "test-fast"]


### PR DESCRIPTION
**Why** is the change needed?

I was struggling with mocha hanging indefinitely on my Ubuntu machine,
something about all workers being busy. My workaround was to run the
tests in a docker container. I'm sharing this since I thought it might
be useful for others.

**How** is the need addressed?

- Add a Dockerfile that sets up the requirements according to the README
- Make docker ignore node-modules
- Add a docker-compose file to run said Dockerfile

Concerns / side-effects of the changes:

This should probably not be merged, but be put in a wiki or something
similar. I thought this was the easiest way to share it, however.
