### PR TITLE
fix: feedback state recreation

### DIFF
--- a/src/commands/feedback-commands/default.ts
+++ b/src/commands/feedback-commands/default.ts
@@ -35,7 +35,7 @@ export const handler = async (argv: argsT): Promise<void> => {
   return graphite(argv, canonical, async (context) => {
     const user = getUserEmail();
     if (!argv.message) {
-      return;
+      throw new ExitFailedError(`No message provided`);
     }
     const response = await request.requestWithArgs(
       API_SERVER,
@@ -48,10 +48,10 @@ export const handler = async (argv: argsT): Promise<void> => {
           : undefined,
       }
     );
-    if (response._response.status == 200) {
+    if (response._response.status === 200) {
       context.splog.info(
         chalk.green(
-          `Feedback received loud and clear (in a team Slack channel) :)`
+          `Feedback received loud and clear (in a team Slack channel) 😊`
         )
       );
     } else {

--- a/src/lib/debug_context.ts
+++ b/src/lib/debug_context.ts
@@ -54,6 +54,8 @@ export function recreateState(stateJson: string, splog: TSplog): string {
   splog.info(`Creating repo`);
   const tmpTrunk = `initial-debug-context-head-${Date.now()}`;
   const tmpDir = tmp.dirSync().name;
+
+  const oldDir = process.cwd();
   process.chdir(tmpDir);
   gpExecSync({
     command: [
@@ -104,6 +106,7 @@ export function recreateState(stateJson: string, splog: TSplog): string {
     switchBranch(tmpTrunk);
   }
 
+  process.chdir(oldDir);
   return tmpDir;
 }
 

--- a/src/lib/git/commit_tree.ts
+++ b/src/lib/git/commit_tree.ts
@@ -2,7 +2,7 @@ import { q } from '../utils/escape_for_shell';
 import { gpExecSyncAndSplitLines } from '../utils/exec_sync';
 
 export function getCommitTree(branchNames: string[]): Record<string, string[]> {
-  const allBranches = q(branchNames.join(' '));
+  const allBranches = branchNames.map((b) => q(b)).join(' ');
   const ret: Record<string, string[]> = {};
   gpExecSyncAndSplitLines({
     command:


### PR DESCRIPTION
**Context:**

When testing the debug context flow, I realized that we were accidentally persisting a graphite cache for the repo the command was run from to the temp folder.

**Changes In This Pull Request:**

Just add the correct chdir to fix this, I think we can probably make this flow not require running in a repo but the command currently does multiple things.

**Test Plan:**

tested locally

