### PR TITLE
fix: allow gt ss from main

### DIFF
--- a/src/actions/submit/submit_action.ts
+++ b/src/actions/submit/submit_action.ts
@@ -47,10 +47,9 @@ export async function submitAction(
     context.splog.newline();
   }
 
-  const branchNames = context.metaCache.getRelativeStack(
-    context.metaCache.currentBranchPrecondition,
-    args.scope
-  );
+  const branchNames = context.metaCache
+    .getRelativeStack(context.metaCache.currentBranchPrecondition, args.scope)
+    .filter((branchName) => !context.metaCache.isTrunk(branchName));
 
   context.splog.info(
     chalk.blueBright(


### PR DESCRIPTION
**Context:**

v0.19 inadvertently broke `gt ss` from main because we were including trunk in the list of branches to submit


**Changes In This Pull Request:**

filter out trunk from the list of branches

**Test Plan:**

![image.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/t6FDnC5t98Dwamvf2BHI/3e80c897-61cf-4bb1-b500-d04205c1cc65/image.png)

