### PR TITLE
fix: autofix of parent revision

### DIFF
--- a/src/lib/engine/parse_branches_and_meta.ts
+++ b/src/lib/engine/parse_branches_and_meta.ts
@@ -171,7 +171,9 @@ export function validateOrFixParentBranchRevision(
   }
 
   // PBR cannot be fixed because its parent is not in its history
-  if (getMergeBase(branchName, parentBranchName) !== parentBranchName) {
+  if (
+    getMergeBase(branchName, parentBranchName) !== parentBranchCurrentRevision
+  ) {
     splog.debug(
       `bad parent rev: ${branchName}\n\t${parentBranchRevision ?? 'missing'}`
     );


### PR DESCRIPTION
**Context:**

I noticed this bug while working on the upstack PR -- merge-base returns a revision, so this condition would never be true.

**Changes In This Pull Request:**

See single line change

**Test Plan:**

Tested locally. 

