### PR TITLE
fix: update parent revision in case where we are based on FF of old parent

### DIFF
--- a/src/lib/engine/parse_branches_and_meta.ts
+++ b/src/lib/engine/parse_branches_and_meta.ts
@@ -166,13 +166,34 @@ export function validateOrFixParentBranchRevision(
     parentBranchRevision &&
     getMergeBase(branchName, parentBranchRevision) === parentBranchRevision
   ) {
+    if (
+      parentBranchRevision !== parentBranchCurrentRevision &&
+      getMergeBase(branchName, parentBranchCurrentRevision) ===
+        parentBranchCurrentRevision
+    ) {
+      // If the parent is ahead of where the metadata has it, we update
+      // it to the current value, as long as it is still in our history
+      writeMetadataRef(branchName, {
+        parentBranchName,
+        parentBranchRevision: parentBranchCurrentRevision,
+        prInfo,
+      });
+      splog.debug(
+        `validated and updated parent rev: ${branchName}\n\t${parentBranchCurrentRevision}`
+      );
+      return {
+        validationResult: 'VALID',
+        parentBranchRevision: parentBranchCurrentRevision,
+      };
+    }
     splog.debug(`validated: ${branchName}`);
     return { validationResult: 'VALID', parentBranchRevision };
   }
 
   // PBR cannot be fixed because its parent is not in its history
   if (
-    getMergeBase(branchName, parentBranchName) !== parentBranchCurrentRevision
+    getMergeBase(branchName, parentBranchCurrentRevision) !==
+    parentBranchCurrentRevision
   ) {
     splog.debug(
       `bad parent rev: ${branchName}\n\t${parentBranchRevision ?? 'missing'}`


### PR DESCRIPTION
**Context:**

User reported bug where after a manual rebase, track/metadata was wacky.
This is because if you have a case where

```
commit 2 - branch B
commit 1 - branch A
```

and you, without graphite, add `commit 1.5` to `branch A` and `git rebase --onto A B~1 B`
then the PBR of B would still be `commit 1`. Graphite would see it as valid because the history looks like:

```
commit 2 - branch B
commit 1.5 - branch A
commit 1
```

and `commit 1` is still in the history of `branch B`, but would show `(needs restack)` because the PBR doesn't match the current commit of `branch A`.  Restacking would just result in a noop.

**Changes In This Pull Request:**

This bug is due to the incorrect implicit assumption that updating a branch would always result in the old version not being in its history; this of course is wrong because you can commit instead of amending or rebasing (or pull and fast-forward trunk). 

The fix is to add another type of on-the-fly update to the cache load - if we see the parent of a branch fast forward, just update the parent revision automatically.

**Test Plan:**

tested locally
