### PR TITLE
feat: better error message for trunk in untrack

### DIFF
--- a/src/actions/untrack_branch.ts
+++ b/src/actions/untrack_branch.ts
@@ -13,6 +13,10 @@ export async function untrackBranch(
     );
   }
 
+  if (context.metaCache.isTrunk(branchName)) {
+    throw new ExitFailedError(`Can't untrack trunk!`);
+  }
+
   if (!context.metaCache.isBranchTracked(branchName)) {
     context.splog.info(
       `Branch ${chalk.yellow(branchName)} is not tracked by Graphite.`


### PR DESCRIPTION
Before they would hit e.g. "main is not tracked by Graphite"