### PR TITLE
fix: --restack on repo sync from trunk

### DIFF
--- a/src/actions/sync/sync.ts
+++ b/src/actions/sync/sync.ts
@@ -69,6 +69,19 @@ export async function syncAction(
   }
 
   const currentBranch = context.metaCache.currentBranch;
+
+  // The below conditional doesn't handle the trunk case because
+  // isBranchTracked returns false for trunk.  Also, in this case
+  // we don't want to append to our existing branchesToRestack
+  // because trunk's stack will include everything anyway.
+  if (currentBranch && context.metaCache.isTrunk(currentBranch)) {
+    restackBranches(
+      context.metaCache.getRelativeStack(currentBranch, SCOPE.STACK),
+      context
+    );
+    return;
+  }
+
   if (
     currentBranch &&
     context.metaCache.branchExists(currentBranch) &&

--- a/src/actions/untrack_branch.ts
+++ b/src/actions/untrack_branch.ts
@@ -13,6 +13,10 @@ export async function untrackBranch(
     );
   }
 
+  if (context.metaCache.isTrunk(branchName)) {
+    throw new ExitFailedError(`Can't untrack trunk!`);
+  }
+
   if (!context.metaCache.isBranchTracked(branchName)) {
     context.splog.info(
       `Branch ${chalk.yellow(branchName)} is not tracked by Graphite.`


### PR DESCRIPTION
Before this `--restack` wouldn't restack all branches as one would expect if run from trunk