### PR TITLE
refactor: cache to spiffy

### DIFF
--- a/src/lib/engine/cache.ts
+++ b/src/lib/engine/cache.ts
@@ -34,11 +34,7 @@ import {
   assertCachedMetaIsValidOrTrunk,
   TValidCachedMetaExceptTrunk,
 } from './cached_meta';
-import {
-  clearPersistedCache,
-  loadCachedBranches,
-  persistCache,
-} from './cache_loader';
+import { composeCacheLoader } from './cache_loader';
 import {
   deleteMetadataRef,
   getMetadataRefList,
@@ -151,9 +147,11 @@ export function composeMetaCache({
   remote: string;
   restackCommitterDateIsAuthorDate?: boolean;
 }): TMetaCache {
+  const cacheLoader = composeCacheLoader(splog);
+  void cacheLoader;
   const cache = {
     currentBranch: currentBranchOverride ?? getCurrentBranchName(),
-    branches: loadCachedBranches(trunkName, splog),
+    branches: cacheLoader.loadCachedBranches(trunkName),
   };
 
   const assertTrunk = () => {
@@ -372,21 +370,21 @@ export function composeMetaCache({
       splog.debug(cuteString(cache));
     },
     persist() {
-      persistCache(trunkName, cache.branches, splog);
+      cacheLoader.persistCache(trunkName, cache.branches);
     },
     clear() {
-      clearPersistedCache(splog);
+      cacheLoader.clearPersistedCache();
     },
     reset(newTrunkName?: string) {
       trunkName = newTrunkName ?? trunkName;
       Object.keys(getMetadataRefList()).forEach((branchName) =>
         deleteMetadataRef(branchName)
       );
-      cache.branches = loadCachedBranches(trunkName, splog);
+      cache.branches = cacheLoader.loadCachedBranches(trunkName);
     },
     rebuild(newTrunkName?: string) {
       trunkName = newTrunkName ?? trunkName;
-      cache.branches = loadCachedBranches(trunkName, splog);
+      cache.branches = cacheLoader.loadCachedBranches(trunkName);
     },
     get trunk() {
       return assertTrunk();

--- a/src/lib/engine/cached_meta.ts
+++ b/src/lib/engine/cached_meta.ts
@@ -2,7 +2,7 @@ import * as t from '@withgraphite/retype';
 import { BadTrunkOperationError, UntrackedBranchError } from '../errors';
 import { prInfoSchema } from './metadata_ref';
 
-const cachedMetaSchema = t.intersection(
+export const cachedMetaSchema = t.intersection(
   t.shape({
     children: t.array(t.string),
     branchRevision: t.string,

--- a/src/lib/engine/metadata_ref.ts
+++ b/src/lib/engine/metadata_ref.ts
@@ -27,7 +27,7 @@ export const prInfoSchema = t.shape({
 });
 export type TBranchPRInfo = t.TypeOf<typeof prInfoSchema>;
 
-export const metaSchema = t.shape({
+const metaSchema = t.shape({
   parentBranchName: t.optional(t.string),
   parentBranchRevision: t.optional(t.string),
   prInfo: t.optional(prInfoSchema),

--- a/src/lib/git/get_sha.ts
+++ b/src/lib/git/get_sha.ts
@@ -10,14 +10,6 @@ export function getShaOrThrow(ref: string): string {
   );
 }
 
-export function getSha(ref: string): string | undefined {
-  return (
-    gpExecSync({
-      command: `git rev-parse ${q(ref)} 2>/dev/null`,
-    }) || undefined
-  );
-}
-
 export function getRemoteSha(ref: string, remote: string): string | undefined {
   const output = gpExecSync({
     command: `git ls-remote ${q(remote)} ${q(ref)}`,

--- a/src/lib/spiffy/cache_spf.ts
+++ b/src/lib/spiffy/cache_spf.ts
@@ -1,8 +1,12 @@
 import * as t from '@withgraphite/retype';
+import { cachedMetaSchema } from '../engine/cached_meta';
 import { spiffy } from './spiffy';
 
 export const cachePersistenceFactory = spiffy({
-  schema: t.array(t.string),
+  schema: t.shape({
+    sha: (sha: unknown): sha is string => t.string(sha) && sha.length === 40,
+    branches: t.array(t.tuple([t.string, cachedMetaSchema])),
+  }),
   defaultLocations: [
     {
       relativePath: '.graphite_cache_persist',
@@ -10,10 +14,10 @@ export const cachePersistenceFactory = spiffy({
     },
   ],
   initialize: () => {
-    return [];
+    return {};
   },
   helperFunctions: () => {
     return {};
   },
-  options: { removeIfEmpty: true },
+  options: { removeIfEmpty: true, removeIfInvalid: true },
 });


### PR DESCRIPTION
**Context:**

There's really no reason to store the meta cache in git refs.  Let's just use spiffy.


**Changes In This Pull Request:**

Replace the cache and cache key refs with a single spiffy.

**Test Plan:**

existing and local tests

