### PR TITLE
feat: branch track --force

### DIFF
--- a/src/actions/track_branch.ts
+++ b/src/actions/track_branch.ts
@@ -56,6 +56,7 @@ export async function trackBranch(
   args: {
     branchName: string | undefined;
     parentBranchName: string | undefined;
+    force: boolean;
   },
   context: TContext
 ): Promise<void> {
@@ -64,7 +65,7 @@ export async function trackBranch(
     throw new ExitFailedError(`No branch found.`);
   }
 
-  if (!args.parentBranchName) {
+  if (args.force || !args.parentBranchName) {
     const choices = context.metaCache.allBranchNames
       .filter(
         (b) =>
@@ -82,7 +83,7 @@ export async function trackBranch(
       );
     }
 
-    if (choices.length === 1) {
+    if (args.force || choices.length === 1) {
       trackHelper({ branchName, parentBranchName: choices[0].value }, context);
       return;
     }

--- a/src/commands/branch-commands/track.ts
+++ b/src/commands/branch-commands/track.ts
@@ -16,6 +16,13 @@ const args = {
     type: 'string',
     alias: 'p',
   },
+  force: {
+    describe: `Sets the parent to the most recent tracked ancestor of the branch being tracked. Takes precedence over \`--parent\``,
+    demandOption: false,
+    default: false,
+    type: 'boolean',
+    alias: 'f',
+  },
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
@@ -33,7 +40,11 @@ export const handler = async (argv: argsT): Promise<void> =>
     canonical,
     async (context) =>
       await trackBranch(
-        { branchName: argv.branch, parentBranchName: argv.parent },
+        {
+          branchName: argv.branch,
+          parentBranchName: argv.parent,
+          force: argv.force,
+        },
         context
       )
   );

--- a/test/fast/commands/branch/track.test.ts
+++ b/test/fast/commands/branch/track.test.ts
@@ -110,5 +110,37 @@ for (const scene of allScenes) {
       scene.repo.execCliCommand('branch down');
       expect(scene.repo.currentBranchName()).to.eq('a');
     });
+
+    it('Tracks the most recent ancestor when `--force` is passed in', () => {
+      // Create our branch
+      scene.repo.createAndCheckoutBranch('a');
+      scene.repo.createChangeAndCommit('a', 'a');
+      scene.repo.createAndCheckoutBranch('b');
+      scene.repo.createChangeAndCommit('b', 'b');
+      expectCommits(scene.repo, 'b, a, 1');
+
+      scene.repo.checkoutBranch('a');
+
+      expect(() => {
+        scene.repo.execCliCommand('branch track -f');
+      }).not.to.throw();
+
+      expect(() => {
+        scene.repo.execCliCommand('branch down');
+      }).not.to.throw();
+      expect(scene.repo.currentBranchName()).to.eq('main');
+
+      scene.repo.checkoutBranch('b');
+      expect(() => {
+        scene.repo.execCliCommand('branch track -f');
+      }).not.to.throw();
+
+      expect(() => {
+        scene.repo.execCliCommand('branch down');
+      }).not.to.throw();
+      expect(scene.repo.currentBranchName()).to.eq('a');
+
+      scene.repo.checkoutBranch('b');
+    });
   });
 }


### PR DESCRIPTION
**Context:**

User pointed out it makes sense to have an option to pick most recent branch as parent

**Changes In This Pull Request:**

Add --force/-f as a way to not have to go through interactive selection, just pick the most reasonable default parent (most recent ancestor)

**Test Plan:**

added UT

