### PR TITLE
fix: formatting on branch rename interactive flow

### DIFF
--- a/src/actions/rename_branch.ts
+++ b/src/actions/rename_branch.ts
@@ -8,11 +8,7 @@ async function getNewBranchName(
   context: TContext,
   oldBranchName: string
 ): Promise<string> {
-  context.splog.newline();
-  context.splog.info(
-    `Enter new name for branch
-    )} ▸ ${chalk.blueBright(oldBranchName)}:`
-  );
+  context.splog.info(`Enter new name for ${chalk.blueBright(oldBranchName)}:`);
 
   const response = await prompts(
     {


### PR DESCRIPTION
Accidentally included some symbols in the prompt
