### PR TITLE
fix: bug with branch rename cached children

### DIFF
--- a/src/actions/rename_branch.ts
+++ b/src/actions/rename_branch.ts
@@ -8,11 +8,7 @@ async function getNewBranchName(
   context: TContext,
   oldBranchName: string
 ): Promise<string> {
-  context.splog.newline();
-  context.splog.info(
-    `Enter new name for branch
-    )} ▸ ${chalk.blueBright(oldBranchName)}:`
-  );
+  context.splog.info(`Enter new name for ${chalk.blueBright(oldBranchName)}:`);
 
   const response = await prompts(
     {

--- a/src/lib/engine/cache.ts
+++ b/src/lib/engine/cache.ts
@@ -526,6 +526,7 @@ export function composeMetaCache({
         setParent(childBranchName, branchName)
       );
 
+      removeChild(cachedMeta.parentBranchName, cache.currentBranch);
       delete cache.branches[cache.currentBranch];
       deleteMetadataRef(cache.currentBranch);
       cache.currentBranch = branchName;


### PR DESCRIPTION
**Context:**

Found the rename bug while I was working on the next PR — bug was that we would include the old name in the cached list of children we store in the metaCache of the parent of the renamed branch

**Changes In This Pull Request:**

Remove the old branch name from the cached children of its parent

**Test Plan:**

it works now
