### PR TITLE
fix: draft publish logic on submit

### DIFF
--- a/src/actions/fold_branch.ts
+++ b/src/actions/fold_branch.ts
@@ -1,0 +1,34 @@
+import chalk from 'chalk';
+import { TContext } from '../lib/context';
+import { SCOPE } from '../lib/engine/scope_spec';
+import { restackBranches } from './restack';
+
+export function foldCurrentBranch(keep: boolean, context: TContext): void {
+  const currentBranchName = context.metaCache.currentBranchPrecondition;
+  const parentBranchName =
+    context.metaCache.getParentPrecondition(currentBranchName);
+  context.metaCache.foldCurrentBranch(keep);
+  if (keep) {
+    context.splog.info(
+      `Folded ${chalk.green(currentBranchName)} into ${chalk.blueBright(
+        parentBranchName
+      )}.`
+    );
+  } else {
+    context.splog.info(
+      `Folded ${chalk.blueBright(currentBranchName)} into ${chalk.green(
+        parentBranchName
+      )}.`
+    );
+    context.splog.tip(
+      `To keep the name of the current branch, use the \`--keep\` flag.`
+    );
+  }
+  restackBranches(
+    context.metaCache.getRelativeStack(
+      context.metaCache.currentBranchPrecondition,
+      SCOPE.UPSTACK_EXCLUSIVE
+    ),
+    context
+  );
+}

--- a/src/actions/submit/prepare_branches.ts
+++ b/src/actions/submit/prepare_branches.ts
@@ -68,8 +68,7 @@ export async function getPRInfoForBranches(
         ? {
             action: 'update' as const,
             prNumber: action.prNumber,
-            draft: args.draft,
-            publish: args.draft,
+            draft: args.draft ? true : args.publish ? false : undefined,
           }
         : {
             action: 'create' as const,
@@ -198,8 +197,11 @@ async function getPRCreationInfo(
     fetchReviewers: args.reviewers,
   });
 
-  const createAsDraft =
-    (args.draft && !args.publish) ?? (await getPRDraftStatus(context));
+  const createAsDraft = args.draft
+    ? true
+    : args.publish
+    ? false
+    : await getPRDraftStatus(context);
 
   return {
     title: submitInfo.title,

--- a/src/commands/branch-commands/fold.ts
+++ b/src/commands/branch-commands/fold.ts
@@ -1,0 +1,25 @@
+import yargs from 'yargs';
+import { foldCurrentBranch } from '../../actions/fold_branch';
+import { graphite } from '../../lib/runner';
+
+const args = {
+  keep: {
+    describe: `Keeps the name of the current branch instead of using the name of its parent.`,
+    demandOption: false,
+    type: 'boolean',
+    alias: 'k',
+    default: false,
+  },
+} as const;
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const aliases = ['f'];
+export const command = 'fold';
+export const canonical = 'branch fold';
+export const description =
+  "Fold a branch's changes into its parent, update dependencies of descendants of the new combined branch, and restack.";
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> =>
+  graphite(argv, canonical, async (context) =>
+    foldCurrentBranch(argv.keep, context)
+  );

--- a/test/fast/commands/branch/branch_fold.test.ts
+++ b/test/fast/commands/branch/branch_fold.test.ts
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+import { allScenes } from '../../../lib/scenes/all_scenes';
+import { configureTest } from '../../../lib/utils/configure_test';
+import { expectBranches } from '../../../lib/utils/expect_branches';
+import { expectCommits } from '../../../lib/utils/expect_commits';
+
+for (const scene of allScenes) {
+  describe(`(${scene}): fold`, function () {
+    configureTest(this, scene);
+
+    it("Can't fold from trunk or into trunk", () => {
+      scene.repo.createChange('a', 'a');
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+
+      expect(() => scene.repo.execCliCommand(`branch fold`)).to.throw();
+      expect(() => scene.repo.execCliCommand(`branch fold --keep`)).to.throw();
+
+      scene.repo.execCliCommand(`branch down`);
+
+      expect(() => scene.repo.execCliCommand(`branch fold`)).to.throw();
+      expect(() => scene.repo.execCliCommand(`branch fold --keep`)).to.throw();
+    });
+
+    it('Can fold without --keep and restack children accordingly', () => {
+      scene.repo.createChange('a', 'a');
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+      scene.repo.createChange('b', 'b');
+      scene.repo.execCliCommand(`branch create "b" -m "b" -q`);
+      scene.repo.createChange('c', 'c');
+      scene.repo.execCliCommand(`branch create "c" -m "c" -q`);
+      scene.repo.execCliCommand(`branch down 2`);
+      scene.repo.createChange('d', 'd');
+      scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
+      scene.repo.checkoutBranch('b');
+
+      scene.repo.execCliCommand(`branch fold`);
+      expectBranches(scene.repo, 'a, c, d, main');
+      expectCommits(scene.repo, 'b, a, 1');
+
+      scene.repo.execCliCommand(`branch down`);
+      expectCommits(scene.repo, '1');
+
+      scene.repo.checkoutBranch('c');
+      expectCommits(scene.repo, 'c, b, a, 1');
+
+      scene.repo.checkoutBranch('d');
+      expectCommits(scene.repo, 'd, b, a, 1');
+    });
+
+    it('Can fold with --keep and restack children accordingly', () => {
+      scene.repo.createChange('a', 'a');
+      scene.repo.execCliCommand(`branch create "a" -m "a" -q`);
+      scene.repo.createChange('b', 'b');
+      scene.repo.execCliCommand(`branch create "b" -m "b" -q`);
+      scene.repo.createChange('c', 'c');
+      scene.repo.execCliCommand(`branch create "c" -m "c" -q`);
+      scene.repo.execCliCommand(`branch down 2`);
+      scene.repo.createChange('d', 'd');
+      scene.repo.execCliCommand(`branch create "d" -m "d" -q`);
+      scene.repo.checkoutBranch('b');
+
+      scene.repo.execCliCommand(`branch fold --keep`);
+      expectBranches(scene.repo, 'b, c, d, main');
+      expectCommits(scene.repo, 'b, a, 1');
+
+      scene.repo.execCliCommand(`branch down`);
+      expectCommits(scene.repo, '1');
+
+      scene.repo.checkoutBranch('c');
+      expectCommits(scene.repo, 'c, b, a, 1');
+
+      scene.repo.checkoutBranch('d');
+      expectCommits(scene.repo, 'd, b, a, 1');
+    });
+  });
+}


### PR DESCRIPTION
First change is for update — bug was that if no args were passed, we would publish drafts on update.
Second change is for create — bug was that if no args were passed, we would always publish.