### PR TITLE
Give PR body temp file a name that should indicate to editors it is a git commit like message

### DIFF
--- a/src/actions/submit/pr_body.ts
+++ b/src/actions/submit/pr_body.ts
@@ -22,6 +22,7 @@ export async function getPRBody(
   }
 
   const editor = context.userConfig.getEditor();
+  const prDescriptionFileName = context.userConfig.getPRDescriptionFileName();
   const response = await prompts(
     {
       type: 'select',
@@ -48,14 +49,16 @@ export async function getPRBody(
   return await editPRBody({
     initial: body,
     editor,
+    prDescriptionFileName
   });
 }
 
 async function editPRBody(args: {
   initial: string;
   editor: string;
+  prDescriptionFileName: {name?: string};
 }): Promise<string> {
-  const file = tmp.fileSync();
+  const file = tmp.fileSync(args.prDescriptionFileName);
   fs.writeFileSync(file.name, args.initial);
   gpExecSync({
     command: `${args.editor} ${file.name}`,

--- a/src/commands/user-commands/pr_description_file_name.ts
+++ b/src/commands/user-commands/pr_description_file_name.ts
@@ -1,0 +1,43 @@
+import chalk from 'chalk';
+import yargs from 'yargs';
+import { graphiteWithoutRepo } from '../../lib/runner';
+
+const args = {
+  set: {
+    demandOption: false,
+    default: '',
+    type: 'string',
+    describe: 'Set default PR description file name for Graphite. eg --set EDIT_DESCRIPTION',
+  },
+  unset: {
+    demandOption: false,
+    default: false,
+    type: 'boolean',
+    describe: 'Unset default PR description file name for Graphite. eg --unset',
+  },
+} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+export const command = 'pr-description-file-name';
+export const description = 'The file name for the PR description created by Graphite';
+export const canonical = 'user pr-description-file-name';
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> => {
+  return graphiteWithoutRepo(argv, canonical, async (context) => {
+    if (argv.set) {
+      context.userConfig.update((data) => (data.prDescriptionFileName = argv.set));
+      context.splog.info(`PR description file name set to ${chalk.cyan(argv.set)}`);
+    } else if (argv.unset) {
+      context.userConfig.update((data) => (data.prDescriptionFileName = undefined));
+      context.splog.info(
+        `PR description file name preference erased. Defaulting to a random file name.`
+      );
+    } else {
+      context.userConfig.data.prDescriptionFileName
+        ? context.splog.info(chalk.cyan(context.userConfig.data.prDescriptionFileName))
+        : context.splog.info(
+            `PR description file name is not set. Graphite will use a random file name.`
+          );
+    }
+  });
+};

--- a/src/lib/spiffy/user_config_spf.ts
+++ b/src/lib/spiffy/user_config_spf.ts
@@ -11,6 +11,7 @@ const schema = t.shape({
   authToken: t.optional(t.string),
   tips: t.optional(t.boolean),
   editor: t.optional(t.string),
+  prDescriptionFileName: t.optional(t.string),
   restackCommitterDateIsAuthorDate: t.optional(t.boolean),
 });
 
@@ -37,6 +38,16 @@ export const userConfigFactory = spiffy({
           'vi'
         );
       },
+      getPRDescriptionFileName: () => {
+        // If we don't have a name set, just return an empty options object
+        if (data.prDescriptionFileName === null || data.prDescriptionFileName === undefined) {
+          return {};
+        } else {
+          return {
+            name: data.prDescriptionFileName
+          }
+        }
+      }
     };
   },
 });

--- a/test/commands/user_config/pr_description_file_name.test.ts
+++ b/test/commands/user_config/pr_description_file_name.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { BasicScene } from '../../lib/scenes/basic_scene';
+import { configureTest } from '../../lib/utils/configure_test';
+
+for (const scene of [new BasicScene()]) {
+  describe(`(${scene}): user PR description file name`, function () {
+    configureTest(this, scene);
+
+    it('Sanity check - can check PR description file name', () => {
+      expect(() => scene.repo.execCliCommand(`user pr-description-file-name`)).to.not.throw(
+        Error
+      );
+    });
+
+    it('Sanity check - can set PR description file name', () => {
+      expect(
+        scene.repo.execCliCommandAndGetOutput(`user pr-description-file-name --set COMMIT_EDITMSG`)
+      ).to.equal('PR description file name set to COMMIT_EDITMSG');
+      expect(scene.repo.execCliCommandAndGetOutput(`user pr-description-file-name`)).to.equal(
+        'COMMIT_EDITMSG'
+      );
+    });
+
+    it('Sanity check - can unset PR description file name', () => {
+      expect(
+        scene.repo.execCliCommandAndGetOutput(`user pr-description-file-name --unset`)
+      ).to.equal(
+        'PR description file name preference erased. Defaulting to a random file name.'
+      );
+    });
+  });
+}


### PR DESCRIPTION
**Context:**
I would like the PR description to be treated like a `gitcommit` file type in NeoVim. To do that the file name needs to match one of the ones at https://github.com/neovim/neovim/blob/d606c39a9cadcf2d627e93b1bdf18bea359d1c63/runtime/filetype.vim#L706-L707. Instead of forcing everyone into this, let's enable a user configuration in case others want a different file type.

**Changes In This Pull Request:**
- Add user config for default PR description temp file name
- Tests for new config

**Test Plan:**
Run the tests locally
