### PR TITLE
feat: change styling for needs restack in ls

### DIFF
--- a/src/actions/log.ts
+++ b/src/actions/log.ts
@@ -294,7 +294,7 @@ function getBranchLines(
         args.noStyleBranchName ||
         context.metaCache.isBranchFixed(args.branchName)
           ? ''
-          : chalk.yellowBright(` (needs restack)`)
+          : chalk.reset(` (needs restack)`)
       }`,
     ];
   }

--- a/src/commands/log-commands/default.ts
+++ b/src/commands/log-commands/default.ts
@@ -21,6 +21,13 @@ const args = {
     alias: 'n',
     default: undefined,
   },
+  'show-untracked': {
+    describe: `Include untracked branched in interactive selection`,
+    demandOption: false,
+    type: 'boolean',
+    positional: false,
+    alias: 'u',
+  },
 } as const;
 
 export const command = '*';
@@ -41,6 +48,7 @@ export const handler = async (argv: argsT): Promise<void> =>
             ? context.metaCache.currentBranchPrecondition
             : context.metaCache.trunk,
         steps: argv.steps,
+        showUntracked: argv['show-untracked'],
       },
       context
     )

--- a/src/commands/log-commands/short.ts
+++ b/src/commands/log-commands/short.ts
@@ -29,6 +29,13 @@ const args = {
     alias: 'n',
     default: undefined,
   },
+  'show-untracked': {
+    describe: `Include untracked branched in interactive selection`,
+    demandOption: false,
+    type: 'boolean',
+    positional: false,
+    alias: 'u',
+  },
 } as const;
 
 export const command = 'short';
@@ -52,6 +59,7 @@ export const handler = async (argv: argsT): Promise<void> =>
                 ? context.metaCache.currentBranchPrecondition
                 : context.metaCache.trunk,
             steps: argv.steps,
+            showUntracked: argv['show-untracked'],
           },
           context
         )


### PR DESCRIPTION
remove the coloring — white looks good now that we have colors on the branch names

![image.png](https://graphite-user-uploaded-assets.s3.amazonaws.com/t6FDnC5t98Dwamvf2BHI/27ba236a-aa82-4859-b6c5-a274e4a11962/image.png)