### PR TITLE
fix: background processes

### DIFF
--- a/src/background_tasks/post_traces.ts
+++ b/src/background_tasks/post_traces.ts
@@ -9,8 +9,6 @@ import { userConfigFactory } from '../lib/spiffy/user_config_spf';
 import { spawnDetached } from '../lib/utils/spawn';
 import { tracer } from '../lib/utils/tracer';
 
-export const SHOULD_REPORT_TELEMETRY = process.env.NODE_ENV != 'development';
-
 function saveTracesToTmpFile(): string {
   const tmpDir = tmp.dirSync();
   const json = tracer.flushJson();
@@ -25,7 +23,7 @@ export function postTelemetryInBackground(): void {
 }
 
 async function postTelemetry(): Promise<void> {
-  if (!SHOULD_REPORT_TELEMETRY) {
+  if (!process.env.GRAPHITE_DISABLE_TELEMETRY) {
     return;
   }
   const tracesPath = process.argv[2];

--- a/src/background_tasks/upgrade_prompt.ts
+++ b/src/background_tasks/upgrade_prompt.ts
@@ -9,7 +9,6 @@ import {
   TMessageConfig,
 } from '../lib/spiffy/upgrade_message_spf';
 import { spawnDetached } from '../lib/utils/spawn';
-import { SHOULD_REPORT_TELEMETRY } from './post_traces';
 
 function printAndClearOldMessage(context: TContextLite): void {
   const oldMessage = context.messageConfig.data.message;
@@ -29,7 +28,7 @@ export function fetchUpgradePromptInBackground(context: TContextLite): void {
 async function fetchUpgradePrompt(
   messageConfig: TMessageConfig
 ): Promise<void> {
-  if (!SHOULD_REPORT_TELEMETRY) {
+  if (process.env.GRAPHITE_DISABLE_UPGRADE_PROMPT) {
     return;
   }
   try {

--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -34,7 +34,8 @@ export class GitRepo {
     gpExecSync({
       command: [
         `${USER_CONFIG_OVERRIDE_ENV}=${this.userConfigPath}`,
-        `NODE_ENV=development`,
+        `GRAPHITE_DISABLE_TELEMETRY=1`,
+        `GRAPHITE_DISABLE_UPGRADE_PROMPT=1`,
         `node ${__dirname}/../../../../dist/src/index.js ${command}`,
       ].join(' '),
       options: {
@@ -60,7 +61,8 @@ export class GitRepo {
     return gpExecSync({
       command: [
         `${USER_CONFIG_OVERRIDE_ENV}=${this.userConfigPath}`,
-        `NODE_ENV=development`,
+        `GRAPHITE_DISABLE_TELEMETRY=1`,
+        `GRAPHITE_DISABLE_UPGRADE_PROMPT=1`,
         `node ${__dirname}/../../../../dist/src/index.js ${command}`,
       ].join(' '),
       options: {

--- a/src/lib/utils/spawn.ts
+++ b/src/lib/utils/spawn.ts
@@ -2,7 +2,7 @@ import cp from 'child_process';
 
 // Spawns an async process that executes the specified file
 export function spawnDetached(filename: string, args: string[] = []): void {
-  cp.spawn('node', [filename, ...args], {
+  cp.spawn(process.argv[0], [filename, ...args], {
     detached: true,
     stdio: 'ignore',
   }).unref();


### PR DESCRIPTION
simpler than what I was trying to figure out earlier, but should work for most cases:

the `SHOULD_REPORT_TELEMETRY` flag just checks if `process.NODE_ENV == 'development'` which I suspect may be true for those that install with npm in a single repo

the node -> process.argv[0] thing should also solve in many cases