### PR TITLE
feat: untrack should untrack the current branch by default

### DIFF
--- a/src/commands/branch-commands/untrack.ts
+++ b/src/commands/branch-commands/untrack.ts
@@ -5,7 +5,7 @@ import { graphite } from '../../lib/runner';
 const args = {
   branch: {
     describe: `Branch to stop tracking.`,
-    demandOption: true,
+    demandOption: false,
     positional: true,
     type: 'string',
     hidden: true,
@@ -20,17 +20,17 @@ const args = {
 } as const;
 type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
 
-export const command = 'untrack <branch>';
+export const command = 'untrack [branch]';
 export const canonical = 'branch untrack';
 export const aliases = ['ut'];
 export const description =
-  'Stop tracking a branch with Graphite. If the branch has children, they will also be untracked.';
+  'Stop tracking a branch with Graphite. If the branch has children, they will also be untracked. Default to the current branch if none is passed in.';
 export const builder = args;
 export const handler = async (argv: argsT): Promise<void> =>
   graphite(argv, canonical, async (context) =>
     untrackBranch(
       {
-        branchName: argv.branch,
+        branchName: argv.branch ?? context.metaCache.currentBranchPrecondition,
         force: argv.force,
       },
       context


### PR DESCRIPTION
as title — this will still prompt before execution if this branch has children
