### PR TITLE
Add markdown extension to description file

### DIFF
--- a/src/actions/submit/pr_body.ts
+++ b/src/actions/submit/pr_body.ts
@@ -76,12 +76,13 @@ export async function getPRBody(
 }
 
 async function editPRBody(initial: string, context: TContext): Promise<string> {
-  // We give the file the name EDIT_DESCRIPTION so certain editors treat it like a commit message
-  // Because of this, we need to create a new directory for each PR body so as to avoid collision
+  // We give the file the name EDIT_DESCRIPTION.md so certain editors treat it like a commit message.
+  // Because of this, we need to create a new directory for each PR body so as to avoid collision.
+  // Having an .md extension is also useful for editors that have markdown mode.
   const dir = tmp.dirSync();
   const file = tmp.fileSync({
     dir: dir.name,
-    name: 'EDIT_DESCRIPTION',
+    name: 'EDIT_DESCRIPTION.md',
   });
   fs.writeFileSync(file.name, initial);
 


### PR DESCRIPTION
**Context:**

`gt stack submit` uses a temp file called `EDIT_DESCRIPTION`, this file is without extension so editors do not provide any syntax or completion.

**Changes In This Pull Request:**

This adds `.md` at the end of the file so that editors get a hint that it's a markdown file.

**Test Plan:**

- Build from source
- `gt stack submit`
- Accept title
- Choose to edit body
- Editor opens /tmp/<id>/EDIT_DESCRIPTION.md
- Hitting enter in this list adds `-` to beginning of my line and i can see markdown syntax highlighting :relieved: 
