### PR TITLE
feat: use edit flag to skip prompts

### DIFF
--- a/src/actions/submit/pr_title.ts
+++ b/src/actions/submit/pr_title.ts
@@ -15,7 +15,7 @@ export async function getPRTitle(
     context.metaCache.getPrInfo(args.branchName)?.title ??
     context.metaCache.getAllCommits(args.branchName, 'SUBJECT').reverse()[0];
 
-  if (!args.editPRFieldsInline) {
+  if (args.editPRFieldsInline === false) {
     return title;
   }
 

--- a/src/actions/submit/prepare_branches.ts
+++ b/src/actions/submit/prepare_branches.ts
@@ -30,7 +30,7 @@ type TPRSubmissionAction = { branchName: string } & (
 export async function getPRInfoForBranches(
   args: {
     branchNames: string[];
-    editPRFieldsInline: boolean;
+    editPRFieldsInline: boolean | undefined;
     draft: boolean;
     publish: boolean;
     updateOnly: boolean;
@@ -174,7 +174,7 @@ async function selectBranch(branchName: string): Promise<boolean> {
 async function getPRCreationInfo(
   args: {
     branchName: string;
-    editPRFieldsInline: boolean;
+    editPRFieldsInline: boolean | undefined;
     draft: boolean;
     publish: boolean;
     reviewers: boolean;

--- a/src/actions/submit/submit_action.ts
+++ b/src/actions/submit/submit_action.ts
@@ -13,7 +13,7 @@ import { validateBranchesToSubmit } from './validate_branches';
 export async function submitAction(
   args: {
     scope: TScopeSpec;
-    editPRFieldsInline: boolean;
+    editPRFieldsInline: boolean | undefined;
     draft: boolean;
     publish: boolean;
     dryRun: boolean;

--- a/src/commands/shared-commands/submit.ts
+++ b/src/commands/shared-commands/submit.ts
@@ -40,7 +40,6 @@ export const args = {
     describe:
       'Edit PR fields inline. If --no-interactive is true, this is automatically set to false.',
     type: 'boolean',
-    default: true,
     alias: 'e',
   },
   'no-edit': {

--- a/test/actions/submit_action.test.ts
+++ b/test/actions/submit_action.test.ts
@@ -21,7 +21,10 @@ for (const scene of [new BasicScene()]) {
       scene.repo.runCliCommand([`branch`, `create`, `a`, `-m`, message]);
 
       expect(
-        await getPRTitle({ branchName: 'a' }, scene.getContext())
+        await getPRTitle(
+          { branchName: 'a', editPRFieldsInline: false },
+          scene.getContext()
+        )
       ).to.equals(title);
       expect(
         inferPRBody(
@@ -35,7 +38,10 @@ for (const scene of [new BasicScene()]) {
         .userConfig.update((data) => (data.submitIncludeCommitMessages = true));
 
       expect(
-        await getPRTitle({ branchName: 'a' }, scene.getContext())
+        await getPRTitle(
+          { branchName: 'a', editPRFieldsInline: false },
+          scene.getContext()
+        )
       ).to.equals(title);
       expect(
         inferPRBody(
@@ -53,7 +59,10 @@ for (const scene of [new BasicScene()]) {
       scene.repo.runCliCommand([`branch`, `create`, `a`, `-m`, commitMessage]);
 
       expect(
-        await getPRTitle({ branchName: 'a' }, scene.getContext())
+        await getPRTitle(
+          { branchName: 'a', editPRFieldsInline: false },
+          scene.getContext()
+        )
       ).to.equals(title);
       expect(
         inferPRBody(
@@ -72,7 +81,10 @@ for (const scene of [new BasicScene()]) {
       scene.repo.createChangeAndCommit(secondSubj);
 
       expect(
-        await getPRTitle({ branchName: 'a' }, scene.getContext())
+        await getPRTitle(
+          { branchName: 'a', editPRFieldsInline: false },
+          scene.getContext()
+        )
       ).to.equals(title);
       expect(
         inferPRBody({ branchName: 'a' }, scene.getContext()).inferredBody
@@ -83,7 +95,10 @@ for (const scene of [new BasicScene()]) {
         .userConfig.update((data) => (data.submitIncludeCommitMessages = true));
 
       expect(
-        await getPRTitle({ branchName: 'a' }, scene.getContext())
+        await getPRTitle(
+          { branchName: 'a', editPRFieldsInline: false },
+          scene.getContext()
+        )
       ).to.equals(title);
       expect(
         inferPRBody({ branchName: 'a' }, scene.getContext()).inferredBody


### PR DESCRIPTION
**Context:**

Provide a way to avoid being prompted about editing changes and just
have the editor opened.

**Changes In This Pull Request:**

* Update `--edit/--no-edit` to have 3 states:
  * When `--edit` is provided, the prompt to edit the description will
    be skippped and an editor will be opened automatically for a PR
    description.
  * When `--no-edit` is provided, the prompt to edit the description
    will be skipped and the default will be used.
  * When neither option is provided, the user will be prompted for
    whether to edit the description or use the default.

**Test Plan:**

* Updated existing tests.
* Verified locally.
