### PR TITLE
fix: get submission info for actions inline

### DIFF
--- a/src/actions/submit/prepare_branches.ts
+++ b/src/actions/submit/prepare_branches.ts
@@ -39,7 +39,7 @@ export async function getPRInfoForBranches(
   },
   context: TContext
 ): Promise<TPRSubmissionInfo> {
-  const prActions = [];
+  const submissionInfo = [];
   for await (const branchName of args.branchNames) {
     const action = await getPRAction(
       {
@@ -52,13 +52,10 @@ export async function getPRInfoForBranches(
       },
       context
     );
-    if (action) {
-      prActions.push(action);
+    if (!action) {
+      continue;
     }
-  }
 
-  const submissionInfo = [];
-  for await (const action of prActions) {
     const parentBranchName = context.metaCache.getParentPrecondition(
       action.branchName
     );


### PR DESCRIPTION
**Context:**
https://linear.app/screenplay/issue/GT-6155/communitybug-should-prompt-right-after-branch-name-in-submit

Currently when we are submitting a stack, we first determine the list of actions to perform and print the output for each step, and then we actually get the information for each action that needs additional info. This causes us to ask for information for a branch action away from when the actual action is outputted to the screen, causing confusion for users.

**Changes In This Pull Request:**

Let's move getting submission information inline to when we determine the action instead of getting all the submission information after getting getting all the actions. 

**Test Plan:**
```
ngobrendan@ip-192-168-86-48 /Users/ngobrendan/graphite/graphite-cli[10-27-step_2] yarn cli ss
🥞 Validating that this Graphite stack is ready to submit...

✏️  Preparing to submit PRs for the following branches...
▸ 10-27-fix_get_submission_info_for_actions_inline (Create)
✔ Title … fix: get submission info for actions inline
✔ Body › Skip (paste template)
✔ Submit › Create Draft Pull Request
▸ 10-27-step_1 (Create)
✔ Title … step 1
✔ Body › Skip (paste template)
✔ Submit › Create Draft Pull Request
▸ 10-27-step_2 (Create)
✔ Title … step 2
✔ Body › Skip (paste template)
✔ Submit › Create Draft Pull Request

📨 Pushing to remote and creating/updating PRs...
10-27-fix_get_submission_info_for_actions_inline: https://app.graphite.dev/github/pr/withgraphite/graphite-cli/1292 (created)
10-27-step_1: https://app.graphite.dev/github/pr/withgraphite/graphite-cli/1293 (created)
10-27-step_2: https://app.graphite.dev/github/pr/withgraphite/graphite-cli/1294 (created)
```