### PR TITLE
update messaging for continues that use git rebase directly

### DIFF
--- a/src/actions/continue.ts
+++ b/src/actions/continue.ts
@@ -28,6 +28,9 @@ export async function continueAction(
       `No Graphite operation to continue — passing through to git.`
     );
     context.splog.info(`Running: "${chalk.yellow('git rebase --continue')}"`);
+    context.splog.info(
+      `Your Graphite state is now out of date. You may need to run stack restack.`
+    );
     context.metaCache.continueGitRebase();
     return;
   }


### PR DESCRIPTION
**Context:**

after https://app.graphite.dev/github/pr/withgraphite/graphite-cli/1318, `gt continue` now runs a `git rebase --continue` if we're in a rebase that's not in a graphite command. However, this could mess up the state of our graphite metadata. 

**Changes In This Pull Request:**

update the messaging around this to make it clear that the graphite state may be out of sync now

**Test Plan:**

```
ngobrendan@ip-192-168-86-164 graphite-cli[11-15-step2] git rebase 11-15-step1
Auto-merging src/actions/continue.ts
CONFLICT (content): Merge conflict in src/actions/continue.ts
error: could not apply 06fc8b1b... step2
hint: Resolve all conflicts manually, mark them as resolved with
hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
hint: You can instead skip this commit: run "git rebase --skip".
hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
Could not apply 06fc8b1b... step2
ngobrendan@ip-192-168-86-164 graphite-cli[(no branch, rebasing 11-15-step2)] git add .             
ngobrendan@ip-192-168-86-164 graphite-cli[(no branch, rebasing 11-15-step2)] yarn cli continue
No Graphite operation to continue — passing through to git.
Running: "git rebase --continue"
Your Graphite state is now out of date. You may need to run stack restack.
ngobrendan@ip-192-168-86-164 graphite-cli[11-15-step2] gt ls
◉      11-15-step2 (needs restack)
◯      11-15-step1
│ ◯    11-15-update_messaging_for_continues_that_use_git_rebase_directly
│ │ ◯  11-15-fix_don_t_require_stages_commits_on_amends
◯─┴─┘  main
ngobrendan@ip-192-168-86-164 graphite-cli[11-15-step2] gt sr
11-15-step1 does not need to be restacked on main.
Restacked 11-15-step2 on 11-15-step1.
```