### PR TITLE
fix: combine continue & update cache

### DIFF
--- a/src/actions/continue.ts
+++ b/src/actions/continue.ts
@@ -23,12 +23,19 @@ export async function continueAction(
   const branchesToRestack = context.continueConfig.data?.branchesToRestack;
 
   if (!rebasedBranchBase) {
-    clearContinuation(context);
     context.splog.info(
       `No Graphite operation to continue — passing through to git.`
     );
+    clearContinuation(context);
+
     context.splog.info(`Running: "${chalk.yellow('git rebase --continue')}"`);
-    context.metaCache.continueGitRebase();
+    const cont = context.metaCache.continueRebase();
+
+    if (cont.result === 'REBASE_CONFLICT') {
+      printConflictStatus(`Rebase conflict is not yet resolved.`, context);
+      throw new RebaseConflictError();
+    }
+
     return;
   }
 


### PR DESCRIPTION
The `continueGitRebase` meta-cache command doesn't run the same post-operation checks & cache updates as `continueRebase`. This change:

* combines the two cache functions, so they both behave consistently and the cache is left in a better state
* on failure exits the CLI with error code, so users & scripts can correctly handle the failure
* shows error information, so user knows what happened & what to do next

```bash
$ gt continue
No Graphite operation to continue — passing through to git.
Running: "git rebase --continue"
Rebase conflict is not yet resolved.

Unmerged files:
yay.txt

You are here (resolving woo):
◯  woo
◯  main

To fix and continue your previous Graphite command:
(1) resolve the listed merge conflicts
(2) mark them as resolved with gt add .
(3) run gt continue to continue executing your previous Graphite command
It's safe to cancel the ongoing rebase with `gt rebase --abort`.
```