### PR TITLE
test: update tests for continue

### DIFF
--- a/src/lib/utils/git_repo.ts
+++ b/src/lib/utils/git_repo.ts
@@ -165,4 +165,12 @@ export class GitRepo {
     this.checkoutBranch(args.branch);
     this.runGitCommand([`merge`, args.mergeIn]);
   }
+
+  trackBranch(branch: string, parentBranch?: string): void {
+    return this.runCliCommand(
+      ['branch', 'track']
+        .concat(parentBranch ? ['--parent', parentBranch] : [])
+        .concat([branch])
+    );
+  }
 }

--- a/test/commands/continue/continue.test.ts
+++ b/test/commands/continue/continue.test.ts
@@ -3,32 +3,83 @@ import { allScenes } from '../../lib/scenes/all_scenes';
 import { configureTest } from '../../lib/utils/configure_test';
 
 for (const scene of allScenes) {
-  describe(`(${scene}): continue`, function () {
+  describe('(${scene}): continue', function () {
     configureTest(this, scene);
 
-    it('Can gt continue a git rebase', () => {
-      scene.repo.createChange('a');
-      scene.repo.runCliCommand([`branch`, `create`, `a`, `-m`, `a`]);
+    beforeEach(function () {
+      scene.repo.createAndCheckoutBranch('a');
+      scene.repo.trackBranch('a', 'main');
+      scene.repo.createChangeAndCommit('a1');
 
-      scene.repo.createChange('b');
-      scene.repo.runCliCommand([`branch`, `create`, `b`, `-m`, `b`]);
+      scene.repo.createAndCheckoutBranch('b');
+      scene.repo.trackBranch('b', 'a');
+      scene.repo.createChangeAndCommit('b1');
 
       scene.repo.checkoutBranch('a');
-      scene.repo.createChangeAndCommit('1');
+      scene.repo.createChangeAndCommit('a2');
+    });
 
-      scene.repo.checkoutBranch('b');
-      expect(() => scene.repo.runCliCommand([`continue`])).to.throw();
+    describe('While not during a rebase', function () {
+      it('Will error', () => {
+        expect(() => scene.repo.runCliCommand(['continue'])).to.throw();
+      });
+    });
 
-      // run a git rebase
-      scene.repo.runGitCommand([`rebase`, `a`]);
-      expect(scene.repo.rebaseInProgress()).to.be.true;
-      scene.repo.resolveMergeConflicts();
-      scene.repo.markMergeConflictsAsResolved();
+    describe('During a git initiated rebase', function () {
+      beforeEach(function () {
+        scene.repo.checkoutBranch('b');
+        scene.repo.runGitCommand(['rebase', 'a']);
+      });
 
-      // Continue should finish running the git rebase
-      expect(() => scene.repo.runCliCommand([`continue`])).to.not.throw();
-      expect(scene.repo.currentBranchName()).to.equal('b');
-      expect(scene.repo.rebaseInProgress()).to.be.false;
+      it('Stops during a rebase', function () {
+        expect(scene.repo.rebaseInProgress()).to.be.true;
+      });
+
+      it('Will not continue', () => {
+        expect(() => scene.repo.runCliCommand(['continue'])).to.throw();
+      });
+
+      describe('After resolving conflict', function () {
+        beforeEach(function () {
+          scene.repo.resolveMergeConflicts();
+          scene.repo.markMergeConflictsAsResolved();
+        });
+
+        it('Will not continue', () => {
+          expect(() => scene.repo.runCliCommand(['continue'])).to.throw();
+        });
+      });
+    });
+
+    describe('During a Grahite initiated rebase', function () {
+      beforeEach(function () {
+        scene.repo.checkoutBranch('b');
+        expect(() => scene.repo.runCliCommand(['stack', 'restack'])).to.throw();
+      });
+
+      it('Stops during a rebase conflict', function () {
+        expect(scene.repo.rebaseInProgress()).to.be.true;
+      });
+
+      it('Will not continue without resolving conflict', function () {
+        expect(() => scene.repo.runCliCommand(['continue'])).to.throw();
+      });
+
+      describe('After resolving conflict and continuing', function () {
+        beforeEach(function () {
+          scene.repo.resolveMergeConflicts();
+          scene.repo.markMergeConflictsAsResolved();
+          scene.repo.runCliCommand(['continue']);
+        });
+
+        it('Lands on the restacked branch', function () {
+          expect(scene.repo.currentBranchName()).to.equal('b');
+        });
+
+        it('No longer is in a rebase', function () {
+          expect(scene.repo.rebaseInProgress()).to.be.false;
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
Update the tests for `gt continue` to reflect behavior of only continuing a Graphite initiated operation.
