### PR TITLE
clarify upstack message

### DIFF
--- a/src/actions/log.ts
+++ b/src/actions/log.ts
@@ -293,7 +293,7 @@ function getBranchLines(
         args.noStyleBranchName ||
         context.metaCache.isBranchFixed(args.branchName)
           ? ''
-          : ` ${chalk.reset(`(needs restack)`)}`
+          : ` ${chalk.reset(`(needs gt upstack restack)`)}`
       }`,
     ];
   }

--- a/src/actions/log_short_classic.ts
+++ b/src/actions/log_short_classic.ts
@@ -15,7 +15,7 @@ function displayBranchesInternal(
     display: `${'  '.repeat(opts.indent ?? 0)}↱ $ ${opts.branchName}${
       context.metaCache.isBranchFixed(opts.branchName)
         ? ''
-        : chalk.yellowBright(` (needs restack)`)
+        : chalk.yellowBright(` (needs gt upstack restack)`)
     }`,
     branchName: opts.branchName,
   };

--- a/src/actions/show_branch.ts
+++ b/src/actions/show_branch.ts
@@ -60,7 +60,7 @@ export function getBranchInfo(
     } ${
       context.metaCache.isBranchFixed(args.branchName)
         ? ''
-        : chalk.yellow(`(needs restack)`)
+        : chalk.yellow(`(needs gt upstack restack)`)
     }`,
     `${chalk.dim(
       context.metaCache.getAllCommits(args.branchName, 'COMMITTER_DATE')[0] ??


### PR DESCRIPTION
After a few months away from `gt` cli, I kind of forgot how to get a restack to occur. From the main help page, it's not clear that `restack` is a subcommand of `upstack` so this change makes it more clear _how to achieve a restack_ whenever the cli is recommending one. 

```
Commands:
  gt auth                 Add your auth token to enable Graphite CLI to create
                          and update your PRs on GitHub.
  gt branch <command>     Commands that operate on your current branch. Run `gt
                          branch --help` to learn more.             [aliases: b]
  gt changelog            Show the Graphite CLI changelog.  [aliases: changelog]
  gt commit <command>     Commands that operate on commits. Run `gt commit
                          --help` to learn more.                    [aliases: c]
  gt completion           Set up bash or zsh tab completion.
  gt continue             Continues the most recent Graphite command halted by a
                          merge conflict.                        [aliases: cont]
  gt dash <command>       Open the web dashboard.                   [aliases: d]
  gt docs                 Show the Graphite CLI docs.            [aliases: docs]
  gt downstack <command>  Commands that operate on a branch and its ancestors.
                          Run `gt downstack --help` to learn more. [aliases: ds]
  gt feedback <command>   Commands for providing feedback and debug state.
  gt log <command>        Commands that log your stacks.            [aliases: l]
  gt repo <command>       Read or write Graphite's configuration settings for
                          the current repo. Run `gt repo --help` to learn more.
                                                                    [aliases: r]
  gt stack <command>      Commands that operate on your current stack of
                          branches. Run `gt stack --help` to learn more.
                                                                    [aliases: s]
  gt upstack <command>    Commands that operate on a branch and its descendants.
                          Run `gt upstack --help` to learn more.   [aliases: us]
  gt user <command>       Read or write Graphite's user configuration settings.
                          Run `gt user --help` to learn more.

Options:
      --version      Show version number                               [boolean]
      --help         Show help                                         [boolean]
      --interactive  Prompt the user. Disable with --no-interactive.
                                                       [boolean] [default: true]
  -q, --quiet        Minimize output to the terminal. [boolean] [default: false]
      --verify       Run git hooks. Disable with --no-verify.
                                                       [boolean] [default: true]
      --debug        Display debug output.            [boolean] [default: false]
```