### PR TITLE
add fish completion

### DIFF
--- a/src/commands/fish.ts
+++ b/src/commands/fish.ts
@@ -1,0 +1,22 @@
+import fs from 'fs-extra';
+import yargs from 'yargs';
+
+import path from 'path';
+import { graphiteWithoutRepo } from '../lib/runner';
+const args = {} as const;
+
+type argsT = yargs.Arguments<yargs.InferredOptionTypes<typeof args>>;
+
+export const command = 'fish';
+export const canonical = 'fish';
+export const aliases = ['fish'];
+export const description = 'Set up fish tab completion.';
+export const builder = args;
+export const handler = async (argv: argsT): Promise<void> =>
+  graphiteWithoutRepo(argv, canonical, async (context) => {
+    context.splog.page(
+      fs.readFileSync(path.join(__dirname, '..', 'lib', 'gt.fish'), {
+        encoding: 'utf-8',
+      })
+    );
+  });

--- a/src/lib/gt.fish
+++ b/src/lib/gt.fish
@@ -1,0 +1,31 @@
+### Installation: gt fish >> ~/.config/fish/completions/gt.fish
+# git helpers adapted from fish git completion
+function __fish_git_local_branches
+    command git for-each-ref --format='%(refname:strip=2)' refs/heads/ 2>/dev/null
+end
+
+function __fish_git_remote_branches
+    command git for-each-ref --format="%(refname:strip=3)" refs/remotes/ 2>/dev/null
+end
+
+# graphite helpers
+function __gt_command_completions
+    set -lx SHELL (type -p fish)
+    set -l command (commandline -opc)
+    # uncomment to include options, e.g. -q, --help
+    # $command --get-yargs-completions
+    # uncomment to exclude options (default)
+    $command --get-yargs-completions | string replace -r '\-.*' ''
+end
+
+# disable file completions for the entire command
+complete -c gt -f
+
+# add completions as provided by CLI
+complete -c gt -a "(__gt_command_completions)"
+
+# commands that take branches
+complete -c gt -x -n "__fish_seen_subcommand_from checkout co bco delete onto track untrack" -a "(__fish_git_local_branches)"
+
+# gt downstack get takes remote branches
+complete -c gt -x -n "__fish_seen_subcommand_from downstack ds dsg" -n "__fish_seen_subcommand_from get dsg" -a "(__fish_git_remote_branches)"


### PR DESCRIPTION
**Context:**

graphite has shell completions for bash ans zsh but completions for fish are missing, see [docs](https://docs.graphite.dev/guides/graphite-cli/installing-the-cli/shell-completion-setup). i wrote the completions script with some help from David Vo (see [slack thread](https://graphite-community.slack.com/archives/C02DRNL3HQU/p1662202082914549)).

i have already been using this script in the current version for ~4 months on linux and fish v3.6, has been working well without any issues.

related feature request: https://app.graphite.dev/changes-requested#request-iUtNG25Lt4gfbZYH15KN

**Changes In This Pull Request:**

adds command `gt fish` which prints out the fish config file. to be used as `gt fish >> ~/.config/fish/completions/gt.fish`.

features:

- supports all commands and sub-commands (gets them from `--get-yargs-completions` so should be future-proof)
- does not support aliases
- completes local branch names after one of: `checkout`, `co`, `bco`, `delete`, `onto`, `track`, `untrack`
- completes remote branch names after one of: `downstack get`, `ds get`, `dsg`

**Note**

i'm not sure if i added the command correctly, and wasn't able to set up a local build to test it, but i'm sure someone here can add any missing pieces. also feel free to move the script file to wherever is more suitable, or rename the command - i wanted to go for `gt complete-fish` but wasn't sure about the naming conventions for multi-word commands etc.

**Test Plan:**

this is a command like `changelog` which just prints out a file content. that one doesn't have tests AFAIK, and i think this one doesn't need it either.