### PR TITLE
feat: CTA in auth error msg 

### DIFF
--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -28,7 +28,7 @@ export const handler = async (argv: argsT): Promise<void> => {
       return;
     }
     context.splog.info(
-      context.userConfig.getAuthToken() ?? 'No auth token set.'
+      context.userConfig.getAuthToken() ?? 'No auth token set. Get it from: https://app.graphite.dev/activate'
     );
   });
 };


### PR DESCRIPTION
**Context:**

Going through onboarding, and when I run `gt auth` the "No auth token set." instruction doesn't direct me to what I should do next. Added a link to graphite site to make cleaner. 

**Changes In This Pull Request:**

Error message change.

**Test Plan:**

Doesn't look like there's unit testing infra for CLI messages, I think this change isn't super risky/should be covered by current set of tests. 
