### PR TITLE
Rename EDIT_DESCRIPTION to have an .md extension for better syntax highlights

### DIFF
--- a/apps/cli/src/actions/submit/pr_body.ts
+++ b/apps/cli/src/actions/submit/pr_body.ts
@@ -81,12 +81,33 @@ export async function editPRBody(
   initial: string,
   context: TContext
 ): Promise<string> {
-  // We give the file the name EDIT_DESCRIPTION so certain editors treat it like a commit message
-  // Because of this, we need to create a new directory for each PR body so as to avoid collision
+  // We used to call this file `EDIT_DESCRIPTION` so editors would treat it like
+  // a Git commit message.
+  //
+  // However, this caused editors like Vim to set the filetype to `gitcommit`,
+  // which would create red/error highlights if the first line went over 50
+  // characters. This was frustrating for users:
+  //
+  //   https://graphite-community.slack.com/archives/C02DRNRA9RA/p1683676287959569
+  //   Also, see GT-8562 in Linear.
+  //
+  // Because we're _really_ editing a Markdown PR description, we should give it
+  // a `.md` extension so every editor can do the smart thing and syntax
+  // highlight it as Markdown.
+  //
+  // We're calling it `GRAPHITE_PR_DESCRIPTION.md` so that users can also
+  // configure their `EDITOR` to do custom things.
+  //
+  // For example, if someone wanted the previous behavior of treating it as a
+  // Git commit message, they could add the following snippet to their Vim
+  // config:
+  //
+  //   autocmd BufNewFile,BufRead GRAPHITE_PR_DESCRIPTION.md set ft=gitcommit
+  //
   const dir = tmp.dirSync();
   const file = tmp.fileSync({
     dir: dir.name,
-    name: 'EDIT_DESCRIPTION',
+    name: 'GRAPHITE_PR_DESCRIPTION.md',
   });
   fs.writeFileSync(file.name, initial);
 


### PR DESCRIPTION
**Context:**

We were treating editing Markdown PR descriptions as the Git commit format inside of `EDITOR`. This is causing bad validations and syntax error highlighting in many cases when writing PR descriptions–namely, if the first line is more than 50 chars in length.

From Slack:

![image](https://github.com/withgraphite/graphite-cli/assets/59429/a4b8c66b-8ed5-48e2-9716-010b9c667120)

> When using vim as gt editor - inherited from being git editor - and editing the PR body, it is started in a mode where it things it is used to edit a commit message.
> This causes it for example to show the first 50 characters of the first line in yellow and the second line with a red background,
> to remind that the subject should be short and that there has to be an empty line between subject and body.
> But while just editing a body, this is meaningless and more disturbs greatly

**Changes In This Pull Request:**

We change the default filename to be `GRAPHITE_PR_DESCRIPTION.md`, which hints the `EDITOR` to syntax highlight as Markdown.

If users want the old behavior in Vim (`set ft=gitcommit`), they can add this snippet to their `~/.vimrc`:

```vim
autocmd BufNewFile,BufRead GRAPHITE_PR_DESCRIPTION.md set ft=gitcommit
```

**Test Plan:**

Tested with `gt bs -e` against a local dev copy, and things work!

### Linear

:sparkles: **EDIT_DESCRIPTION should have an .md extension for Vim syntax highlighting**
:globe_with_meridians: [GT-8562](https://linear.app/withgraphite/issue/GT-8562/edit-description-should-have-an-md-extension-for-vim-syntax)

<details>
  <summary>Description</summary>

  ![image.png](https://uploads.linear.app/24f8a1a2-bac0-4c2a-94b6-d23224c57e6f/7c1817f2-83a6-44e5-a76c-6a0677aaaa57/733a1cfe-6435-4f43-b805-a5b666e77a90)
</details>

Closes GT-8562
