### PR TITLE
Use `git diff --quiet` to check for changes

### DIFF
--- a/apps/cli/src/lib/git/runner.ts
+++ b/apps/cli/src/lib/git/runner.ts
@@ -84,6 +84,8 @@ function runGitCommandInternal(params: TRunGitCommandParameters): string {
 }
 
 export class CommandFailedError extends Error {
+  status: number;
+
   constructor(failure: {
     command: string;
     args: string[];
@@ -104,6 +106,7 @@ export class CommandFailedError extends Error {
       ].join('\n')
     );
     this.name = 'CommandFailed';
+    this.status = failure.status;
   }
 }
 


### PR DESCRIPTION
**Context:**

Various commands that were checking whether a diff exists could be slow. It turns out those were calling `git diff --shortstat`, which requires git to count the number of changed lines, but were then ignoring the output.

**Changes In This Pull Request:**

This replaces the usages of `git diff --shortstat` with `git diff --quiet`, to allow git to exit early after finding any file that has been touched.

**Measurements:**

`gt rs` checking whether branches of mine are empty, on a 2019 MacBook Pro:

- Recent branch
  - Before: 524 ms
  - After: 39 ms
- Old deletable branch
  - Before: 43 seconds
  - After: 59 ms

**Test Plan:**
