### PR TITLE
fix: dont show draft checkbox when creating a new branch

### DIFF
--- a/apps/gti-client/src/CommitInfoView/CommitInfoView.tsx
+++ b/apps/gti-client/src/CommitInfoView/CommitInfoView.tsx
@@ -518,9 +518,9 @@ const ActionsBar = observer(
         data-testid="commit-info-actions-bar"
       >
         <div className="commit-info-actions-bar-left">
-          <SubmitAsDraftCheckbox
-            commitsToBeSubmit={isCommitMode ? [] : [commit]}
-          />
+          {isCommitMode ? null : (
+            <SubmitAsDraftCheckbox commitsToBeSubmit={[commit]} />
+          )}
         </div>
         <div className="commit-info-actions-bar-right">
           {isAnythingBeingEdited && !isCommitMode ? (


### PR DESCRIPTION
we do this differently from ISL, (no local concept of draft status)